### PR TITLE
Rename the source-build intermediate package

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <GitHubRepositoryName>source-build</GitHubRepositoryName>
+    <GitHubRepositoryName>source-build-externals</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 


### PR DESCRIPTION
Renamed the source-build intermediate package to align with the new repo name after migrating from dotnet/source-build

Related https://github.com/dotnet/source-build/issues/2625