### PR TITLE
Remove source-build prebuilts

### DIFF
--- a/repos/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
+++ b/repos/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
@@ -14,6 +14,8 @@
       <SystemIdentityModelTokensJwtProject>$(ProjectDirectory)src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj</SystemIdentityModelTokensJwtProject>
       <MicrosoftIdentityModelsTokenProject>$(ProjectDirectory)src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj</MicrosoftIdentityModelsTokenProject>
       <MicrosoftIdentityModelJsonWebTokensProject>$(ProjectDirectory)src/Microsoft.IdentityModel.JsonWebTokens/Microsoft.IdentityModel.JsonWebTokens.csproj</MicrosoftIdentityModelJsonWebTokensProject>
+      <MicrosoftIdentityModelAbstractionsProject>$(ProjectDirectory)src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj</MicrosoftIdentityModelAbstractionsProject>
+      <MicrosoftIdentityModelLoggingProject>$(ProjectDirectory)src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj</MicrosoftIdentityModelLoggingProject>
 
       <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftSourceLinkVersion=$(MicrosoftSourceLinkVersion)</BuildCommandArgs>
@@ -45,6 +47,16 @@
           IgnoreStandardErrorWarningFormat="true" />
 
     <Exec Command="$(DotnetToolCommand) pack /bl:pack_JsonWebTokens.binlog $(MicrosoftIdentityModelJsonWebTokensProject) $(PackCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack_Abstractions.binlog $(MicrosoftIdentityModelAbstractionsProject) $(PackCommandArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <Exec Command="$(DotnetToolCommand) pack /bl:pack_Logging.binlog $(MicrosoftIdentityModelLoggingProject) $(PackCommandArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)"
           IgnoreStandardErrorWarningFormat="true" />


### PR DESCRIPTION
https://github.com/dotnet/source-build-externals/pull/28 brought in a couple IdentityModel PRs that needs to be addressed.  The issue is that the packages are built but not getting packaged.