### PR TITLE
Specify the NuGetConfigFiles in the Application-Insights repo project

### DIFF
--- a/repos/application-insights.proj
+++ b/repos/application-insights.proj
@@ -7,6 +7,11 @@
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
   </PropertyGroup>
 
+  <ItemGroup>
+    <NuGetConfigFiles Include="$(ProjectDirectory)/NuGet.config" />
+    <NuGetConfigFiles Include="$(ProjectDirectory)/BASE/NuGet.config" />
+  </ItemGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <Target Name="RepoBuild">


### PR DESCRIPTION
The repo's nuget configs are not getting handled correctly by the source-build-externals [logic](https://github.com/dotnet/source-build-externals/blob/main/repos/Directory.Build.targets#L50) to update the NuGet configs to include the source-build specific feeds.  This is blocking https://github.com/dotnet/installer/pull/14261.