### PR TITLE
Update main versioning to 8.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <MajorVersion>7</MajorVersion>
+    <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>


### PR DESCRIPTION
7.0 work has branched to https://github.com/dotnet/source-build-externals/tree/release/7.0.  Versioning in main needs to be updated to 8.0.