### PR TITLE
Use latest docker containers

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -40,7 +40,7 @@ stages:
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
         workspace:
           clean: all
         variables:

--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -40,7 +40,7 @@ stages:
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
         workspace:
           clean: all
         variables:


### PR DESCRIPTION
This change moves all of the docker images to the latest tag as part of https://github.com/dotnet/arcade/issues/10377.