### PR TITLE
Correct Humanizer NuPkg version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,4 @@
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
   </PropertyGroup>
-  <!-- Humanizer expects us to tell the version it's building -->
-  <PropertyGroup>
-    <HumanizerCorePackageVersion>2.2.0</HumanizerCorePackageVersion>
-  </PropertyGroup>
 </Project>

--- a/repos/humanizer.proj
+++ b/repos/humanizer.proj
@@ -6,6 +6,7 @@
     <RepoApiImplemented>false</RepoApiImplemented>
     <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
     <NuGetConfigFile>$(ProjectDirectory)/src/NuGet.config</NuGetConfigFile>
+    <HumanizerCorePackageVersion>2.14.1</HumanizerCorePackageVersion>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
When Humanizer was upgraded from 2.2.0 to 2.14.1 in https://github.com/dotnet/source-build-externals/pull/52, the HumanizerCorePackageVersion property was missed.  The result is that the Humanizer NuPkg package version was incorrect.  This was surfaced in the repo-level prebuilt detection work where repos that depend on 2.14.1 were unable to find the version from source-build-externals.  This wasn't an issue in the full product build because of the pvp flow.

I decided to move the version property into the Humanizer repo project to make the repos more self contained.  This would have helped prevent this oversight.