### PR TITLE
Update ApplicationInsights to 2.21.0

### DIFF
--- a/patches/application-insights/0001-Eliminate-prebuilts.patch
+++ b/patches/application-insights/0001-Eliminate-prebuilts.patch
@@ -1,29 +1,22 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: MichaelSimons <msimons@microsoft.com>
-Date: Wed, 4 May 2022 17:42:31 +0000
+From: ViktorHofer <viktor.hofer@microsoft.com>
+Date: Wed, 19 April 2023 18:42:00 +0000
 Subject: [PATCH] Eliminate prebuilts
 
 ---
- .props/Product.props | 9 +--------
- 1 file changed, 1 insertion(+), 8 deletions(-)
+ .props/Product.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletions(-)
 
 diff --git a/.props/Product.props b/.props/Product.props
-index da6f6ec3..cec2ee58 100644
+index e97b6eff..6183fbb6 100644
 --- a/.props/Product.props
 +++ b/.props/Product.props
-@@ -32,14 +32,7 @@
+@@ -29,7 +29,7 @@
    </ItemGroup>
  
    <ItemGroup>
--    <!--Build Infrastructure-->
--    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
--      <PrivateAssets>All</PrivateAssets>
--    </PackageReference>
--  </ItemGroup>
--
--  <ItemGroup>
 -    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 +    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
    </ItemGroup>
-   
+ 
    <PropertyGroup>


### PR DESCRIPTION
The current used SHA which maps to 2.20.0 is already flagged as deprecated on nuget.org.

Upgrading to 2.21.0 and then updating the consumers (arcade).

@MichaelSimons @mmitche 