### PR TITLE
Downgrade ApplicationInsights to 2.21.0

### DIFF
--- a/patches/application-insights/0001-Eliminate-prebuilts.patch
+++ b/patches/application-insights/0001-Eliminate-prebuilts.patch
@@ -1,22 +1,29 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: ViktorHofer <viktor.hofer@microsoft.com>
-Date: Wed, 19 April 2023 18:42:00 +0000
+From: MichaelSimons <msimons@microsoft.com>
+Date: Wed, 4 May 2022 17:42:31 +0000
 Subject: [PATCH] Eliminate prebuilts
 
 ---
- .props/Product.props | 2 +-
- 1 file changed, 1 insertion(+), 1 deletions(-)
+ .props/Product.props | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
 
 diff --git a/.props/Product.props b/.props/Product.props
-index e97b6eff..6183fbb6 100644
+index da6f6ec3..cec2ee58 100644
 --- a/.props/Product.props
 +++ b/.props/Product.props
-@@ -29,7 +29,7 @@
+@@ -32,14 +32,7 @@
    </ItemGroup>
  
    <ItemGroup>
+-    <!--Build Infrastructure-->
+-    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+-      <PrivateAssets>All</PrivateAssets>
+-    </PackageReference>
+-  </ItemGroup>
+-
+-  <ItemGroup>
 -    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 +    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
    </ItemGroup>
- 
+   
    <PropertyGroup>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/source-build-externals/commit/d1db09ce5c5a2aeab37d01336765861c0283f76f

Accidentally went too far, up to the latest commit in ApplicationInsights. Instead, we want the 2.21.0 head commit: 5e2e7ddda961ec0e16a75b1ae0a37f6a13c777f5