### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-* @MichaelSimons @crummel @lbussell
+* @MichaelSimons @mthalman


### PR DESCRIPTION
I am using individuals vs a team because when a team is used and one person signs off, the team is dropped from the reviewers.