### PR TITLE
Remove aspnetcore prebuild from MSBuildLocator and other externals

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -80,6 +80,9 @@
 
     <EnvironmentVariables Include="DeterministicSourcePaths=false" />
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
+    
+    <!-- Disable restoring transitive aspnetcore and windowsdesktop targeting packs to avoid unnecessary prebuilds. -->
+    <EnvironmentVariables Include="DisableTransitiveFrameworkReferenceDownloads=true" />
   </ItemGroup>
 
 </Project>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -81,7 +81,7 @@
     <EnvironmentVariables Include="DeterministicSourcePaths=false" />
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
     
-    <!-- Disable restoring transitive aspnetcore and windowsdesktop targeting packs to avoid unnecessary prebuilds. -->
+    <!-- Disable restoring transitive aspnetcore and windowsdesktop targeting packs to avoid unnecessary dependencies. -->
     <EnvironmentVariables Include="DisableTransitiveFrameworkReferenceDownloads=true" />
   </ItemGroup>
 


### PR DESCRIPTION
The SDK by default restores transitive targeting packs Microsoft.AspNetCore.App.Ref and Microsoft.WindowsDesktop.App.Ref but provides an opt-out switch `DisableTransitiveFrameworkReferenceDownloads=true`.

As these transitive targeting packs are usually not needed and definitely not for source-build-externals, disabling them via an environment variable so that the setting applies to all external projects in the tree.