### PR TITLE
IdentityModel patch to remove commit SHA

### DIFF
--- a/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0002-Remove-commit-SHA-from-version-string.patch
+++ b/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0002-Remove-commit-SHA-from-version-string.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Thalman <mthalman@microsoft.com>
+Date: Wed, 30 Aug 2023 09:10:55 -0500
+Subject: [PATCH] Remove commit SHA from version string
+
+Needs https://github.com/dotnet/source-build/issues/3573
+---
+ updateAssemblyInfo.sh | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/updateAssemblyInfo.sh b/updateAssemblyInfo.sh
+index abbcfac6..2c6a119e 100755
+--- a/updateAssemblyInfo.sh
++++ b/updateAssemblyInfo.sh
+@@ -9,11 +9,9 @@ date=$(date '+%y%m%d%H%M%S')
+ # Formats the date by replacing the 4-digit year with a 2-digit value and then subtract 19
+ dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
+ 
+-commitSha=$(git rev-parse HEAD)
+-
+ assemblyVersion=$(sed -n 's/.*<assemblyVersion>\([^<]*\)<.*/\1/p' $PWD/buildConfiguration.xml)
+ assemblyFileVersion="$assemblyVersion.${dateTimeStamp::-6}" # Trim minutes/seconds
+-assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp.$commitSha"
++assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp"
+ 
+ echo "assemblyVersion: $assemblyVersion"
+ echo "assemblyFileVersion: $assemblyFileVersion"


### PR DESCRIPTION
The changes from https://github.com/dotnet/source-build-externals/pull/198 are causing the following build error when built in the context of a synchronized VMR build leg:

```
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

This is related to https://github.com/dotnet/source-build/issues/3573. We can't execute `git` commands in the build and don't yet have predefined git info we can use.