### PR TITLE
MSBuildLocator 1.6.10

### DIFF
--- a/repo-projects/MSBuildLocator.proj
+++ b/repo-projects/MSBuildLocator.proj
@@ -15,6 +15,7 @@
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:DelaySign=$(DelaySign)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:PublicSign=$(PublicSign)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:EnablePackageValidation=false</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:Version=1.6.10</BuildCommandArgs>
     </PropertyGroup>
 

--- a/repo-projects/MSBuildLocator.proj
+++ b/repo-projects/MSBuildLocator.proj
@@ -15,7 +15,7 @@
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:DelaySign=$(DelaySign)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:PublicSign=$(PublicSign)</BuildCommandArgs>
-      <BuildCommandArgs>$(BuildCommandArgs) /p:Version=1.6.1</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Version=1.6.10</BuildCommandArgs>
     </PropertyGroup>
 
     <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)"


### PR DESCRIPTION
This is #213 plus a fix to disable package validation, which doesn't make sense for the source-built package (which deliberately changes TFs).