### PR TITLE
Add Spectre.Console latest (0.48.0) to Source Build 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "abstractions-xunit"]
 	path = src/abstractions-xunit
 	url = https://github.com/xunit/abstractions.xunit
+[submodule "src/spectre-console"]
+	path = src/spectre-console
+	url = https://github.com/spectreconsole/spectre.console

--- a/patches/spectre-console/0001-remove-packagereferences-for-build.patch
+++ b/patches/spectre-console/0001-remove-packagereferences-for-build.patch
@@ -1,0 +1,33 @@
+From ad9eef0f848288b6fdc23c93e6e90f367d62c361 Mon Sep 17 00:00:00 2001
+From: baronfel <chusk3@gmail.com>
+Date: Mon, 18 Dec 2023 14:09:06 -0600
+Subject: [PATCH] wip
+
+---
+ src/Directory.Build.props | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 6bf853f..59c8130 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -31,7 +31,7 @@
+     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+   </PropertyGroup>
+   
+-  <ItemGroup Label="Package References">
++  <!-- <ItemGroup Label="Package References">
+     <PackageReference Include="MinVer" PrivateAssets="All" Version="4.2.0" />
+     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.1.1" />
+     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+@@ -40,5 +40,5 @@
+     <PackageReference Include="Roslynator.Analyzers" Version="4.1.2">
+       <PrivateAssets>All</PrivateAssets>
+     </PackageReference>
+-  </ItemGroup>
++  </ItemGroup> -->
+ </Project>
+\ No newline at end of file
+-- 
+2.40.1
+

--- a/repo-projects/spectre-console.proj
+++ b/repo-projects/spectre-console.proj
@@ -1,0 +1,38 @@
+<Project>
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  
+    <PropertyGroup>
+      <PackagesOutput>$(ProjectDirectory)/src/Spectre.Console/bin/$(Configuration)/</PackagesOutput>
+      <SpectreConsolePackageVersion>0.48.0</SpectreConsolePackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  
+    <Target Name="RepoBuild">
+      <PropertyGroup>
+        <BuildCommandArgs>$(ProjectDirectory)/src/Spectre.Console/Spectre.Console.csproj</BuildCommandArgs>
+        <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
+        <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
+        <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+        <BuildCommandArgs>$(BuildCommandArgs) /p:Version=$(SpectreConsolePackageVersion)</BuildCommandArgs>
+        <BuildCommandArgs>$(BuildCommandArgs) /p:TargetFrameworks=$(NetCurrent)</BuildCommandArgs>
+      </PropertyGroup>
+  
+      <Exec Command="$(DotnetToolCommand) restore /bl:restore.binlog $(BuildCommandArgs)"
+            EnvironmentVariables="@(EnvironmentVariables)"
+            WorkingDirectory="$(ProjectDirectory)"
+            IgnoreStandardErrorWarningFormat="true" />
+  
+      <Exec Command="$(DotnetToolCommand) build /bl:build.binlog $(BuildCommandArgs)"
+            EnvironmentVariables="@(EnvironmentVariables)"
+            WorkingDirectory="$(ProjectDirectory)"
+            IgnoreStandardErrorWarningFormat="true" />
+  
+      <Exec Command="$(DotnetToolCommand) pack /bl:pack.binlog $(BuildCommandArgs)"
+            EnvironmentVariables="@(EnvironmentVariables)"
+            WorkingDirectory="$(ProjectDirectory)"
+            IgnoreStandardErrorWarningFormat="true" />
+    </Target>
+  
+  </Project>
+  


### PR DESCRIPTION
MSBuild and the SDK would like to use some of the interactivity and console layout features from Spectre without reinventing the wheel, and a prereq for that is Spectre.Console being part of source build.

This adds the latest package (0.48.0) tags to source build, but specifically just the primary project/package for the Spectre project. This project contains the vast majority of the UI/layout functions and should serve all of our needs.