### PR TITLE
Migrate to 1ES pipeline templates

### DIFF
--- a/.vsts.pipelines/builds/ci-public.yml
+++ b/.vsts.pipelines/builds/ci-public.yml
@@ -1,0 +1,51 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    exclude:
+    - '*.md'
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+  paths:
+    exclude:
+    - '*.md'
+
+variables:
+  - name: Codeql.Enable
+    value: true
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: true
+      artifacts:
+        publish:
+          artifacts: true
+          manifests: true
+      jobs:
+      - job: SourceBuild_Managed
+        displayName: Source-Build (Managed)
+        pool:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+        workspace:
+          clean: all
+        variables:
+        - name: _BuildConfig
+          value: Release
+        steps:
+        - checkout: self
+          submodules: recursive
+        - template: /eng/common/templates/steps/source-build.yml

--- a/.vsts.pipelines/builds/ci-public.yml
+++ b/.vsts.pipelines/builds/ci-public.yml
@@ -18,6 +18,7 @@ pr:
     - '*.md'
 
 variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
   - name: Codeql.Enable
     value: true
 

--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -7,7 +7,6 @@ trigger:
   paths:
     exclude:
     - '*.md'
-
 pr:
   branches:
     include:
@@ -16,49 +15,62 @@ pr:
   paths:
     exclude:
     - '*.md'
-
 variables:
-  - name: Codeql.Enable
-    value: true
-
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enablePublishUsingPipelines: true
-      enablePublishBuildAssets: true
-      artifacts:
-        publish:
-          artifacts: true
-          manifests: true
+- template: /eng/common/templates-official/variables/pool-providers.yml
+- name: TeamName
+  value: DotNetSourceBuild
+- name: Codeql.Enable
+  value: true
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022-pt
+        os: windows
+      suppression:
+          suppressionFile: $(Build.SourcesDirectory)\.vsts.pipelines\guardian\.gdnsuppress
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build
       jobs:
-
-      - job: SourceBuild_Managed
-        displayName: Source-Build (Managed)
-        pool:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-        workspace:
-          clean: all
-        variables:
-        - name: _BuildConfig
-          value: Release
-        steps:
-        - checkout: self
-          submodules: recursive
-        - template: /eng/common/templates/steps/source-build.yml
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      enableSourceLinkValidation: true
-      enableSigningValidation: false
-
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enablePublishUsingPipelines: true
+          enablePublishBuildAssets: true
+          artifacts:
+            publish:
+              artifacts: true
+              manifests: true
+          jobs:
+          - job: SourceBuild_Managed
+            displayName: Source-Build (Managed)
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: 1es-ubuntu-2204-pt
+              os: linux
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+            workspace:
+              clean: all
+            variables:
+            - name: _BuildConfig
+              value: Release
+            steps:
+            - checkout: self
+              submodules: recursive
+            - template: /eng/common/templates-official/steps/source-build.yml
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
+        parameters:
+          publishingInfraVersion: 3
+          enableSourceLinkValidation: true
+          enableSigningValidation: false

--- a/.vsts.pipelines/guardian/.gdnsuppress
+++ b/.vsts.pipelines/guardian/.gdnsuppress
@@ -1,0 +1,207 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/suppressions",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "suppressionSets": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-03-07 17:09:14Z",
+      "lastUpdatedDate": "2024-03-07 17:09:14Z"
+    }
+  },
+  "results": {
+    "31128318971be3d77cbd3aaf7b6a06d65b1874334a143ee500c7fccb5aa89427": {
+      "signature": "31128318971be3d77cbd3aaf7b6a06d65b1874334a143ee500c7fccb5aa89427",
+      "alternativeSignatures": [
+        "9106dc3b9a335702dc4feeeed54285f07d8a06494f38fc23167f6158793928dc"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "992b26983b997813a410dfc25048f3b218c6fc02fc14a5c2ad431ec8e022ac79": {
+      "signature": "992b26983b997813a410dfc25048f3b218c6fc02fc14a5c2ad431ec8e022ac79",
+      "alternativeSignatures": [
+        "23e97da32b7142c282727c96d07fd5ce6aefd6ef26f02e91cb471eb7863542f8"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "53b10a5fb6059b0b229ad32c6278123a5603386f65d9e1c5684a2333f2e1dc62": {
+      "signature": "53b10a5fb6059b0b229ad32c6278123a5603386f65d9e1c5684a2333f2e1dc62",
+      "alternativeSignatures": [
+        "cd7b0b0937cfa32a98962a528bd99ede0181ae41a609df430f35fd30763166c4"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "826c1d41ea210af2fc3a7ff120c606aecee5bede4bba54c10512a998f53fafd0": {
+      "signature": "826c1d41ea210af2fc3a7ff120c606aecee5bede4bba54c10512a998f53fafd0",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "2123572b79400b0335c85250c4aff8f6142cea7a437a37153904f79ddafa64fc": {
+      "signature": "2123572b79400b0335c85250c4aff8f6142cea7a437a37153904f79ddafa64fc",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "3eced103c90fbc6d04eb6af47fd6213563948693acfc44c884d4feef4f4c4900": {
+      "signature": "3eced103c90fbc6d04eb6af47fd6213563948693acfc44c884d4feef4f4c4900",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "1ef98823231057834e7ee94c5b5b8316a736ab1a66bce45df0455867c7562fe9": {
+      "signature": "1ef98823231057834e7ee94c5b5b8316a736ab1a66bce45df0455867c7562fe9",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "fbcf8ea13d120926f0777f7f73d318d9ef6f18c9e88b844993e1bc7ba7cfc79c": {
+      "signature": "fbcf8ea13d120926f0777f7f73d318d9ef6f18c9e88b844993e1bc7ba7cfc79c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "84d9c760946210c88b698e6084f5db7a33353ecef49fa9dfaf424b545014980b": {
+      "signature": "84d9c760946210c88b698e6084f5db7a33353ecef49fa9dfaf424b545014980b",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "a0bb972ab1a203ccb881e90b3593b65127f78d0dc007c5ca83e1e6d07338e8c3": {
+      "signature": "a0bb972ab1a203ccb881e90b3593b65127f78d0dc007c5ca83e1e6d07338e8c3",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "7363daf29c8c84a8ed6991e3c7fc3eb44115b0403b6b47fac99a9aa2cd3b1998": {
+      "signature": "7363daf29c8c84a8ed6991e3c7fc3eb44115b0403b6b47fac99a9aa2cd3b1998",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "a9485af66c8f757c02c53aa5f7cf02cde5c1c9e60e8c70768ff3a124486fa3a7": {
+      "signature": "a9485af66c8f757c02c53aa5f7cf02cde5c1c9e60e8c70768ff3a124486fa3a7",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "d95887551b5f4f802485e351daca216de95c8a328bab614ddefc518b1acfed26": {
+      "signature": "d95887551b5f4f802485e351daca216de95c8a328bab614ddefc518b1acfed26",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "9cfa6b8f64d95cf2469afcef66aae5e9c76c64a671b082ff42d00ce42c434aff": {
+      "signature": "9cfa6b8f64d95cf2469afcef66aae5e9c76c64a671b082ff42d00ce42c434aff",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "9c75c0e9d0e58ff6d39b74a0d8326609b8465c59ac2b03eccc7eaf4f50ae32d1": {
+      "signature": "9c75c0e9d0e58ff6d39b74a0d8326609b8465c59ac2b03eccc7eaf4f50ae32d1",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "74856bc4ed4c67c9c0c6c69c7e8a3a01ffcf7f9a89d332ca68a0e6ecb51ad511": {
+      "signature": "74856bc4ed4c67c9c0c6c69c7e8a3a01ffcf7f9a89d332ca68a0e6ecb51ad511",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "7318b6ff65864c4b5cc05a2439ffc3b7be06114f2a7007da6253fed91d1c9e56": {
+      "signature": "7318b6ff65864c4b5cc05a2439ffc3b7be06114f2a7007da6253fed91d1c9e56",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "b35cc2f8fe7a2aba483d0f29517153876385314dffb249548530d2e5463bdf93": {
+      "signature": "b35cc2f8fe7a2aba483d0f29517153876385314dffb249548530d2e5463bdf93",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "8d3d289c461dd6454c98dbcaa5fef608dae8a32c68929cffc6a9db8b2826b840": {
+      "signature": "8d3d289c461dd6454c98dbcaa5fef608dae8a32c68929cffc6a9db8b2826b840",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "6bb3b72839c43d3ff9a6aba1e5cc5708f01865416f020d1a26643cffff8fa74f": {
+      "signature": "6bb3b72839c43d3ff9a6aba1e5cc5708f01865416f020d1a26643cffff8fa74f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "2610d6745224ba98106d22e2c66c4abce8ffafecb57f444ed8a0f2a542fa0538": {
+      "signature": "2610d6745224ba98106d22e2c66c4abce8ffafecb57f444ed8a0f2a542fa0538",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "40d2ad8a369cd2c1f07465a2a68b6dc202f5ea371c2576f2b0cc18c82f3aa675": {
+      "signature": "40d2ad8a369cd2c1f07465a2a68b6dc202f5ea371c2576f2b0cc18c82f3aa675",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    },
+    "affacdd646b09264bc94c75ff52aafe58f0cd1f2c09cb50033014c38c4823d86": {
+      "signature": "affacdd646b09264bc94c75ff52aafe58f0cd1f2c09cb50033014c38c4823d86",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 17:09:14Z"
+    }
+  }
+}


### PR DESCRIPTION
Splits the existing CI pipeline into two separate pipelines:
* ci-public.yml: for public builds - This is the same as the original content except that conditional logic has been removed that was meant to support internal builds.
* ci.yml: for internal builds - Uses the 1ES pipeline template pattern

The SDL stage revealed some credscan errors coming from arcade (eng/common) and various repos defined as submodules in SBE. The Arcade ones will need to be addressed by the Arcade team. For the others, these are external and so not actionable by us. These have all been added as suppressions.