### PR TITLE
Add explanation for when a toolset repo has an SBE dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ may need to flow in at the same time as the cooresponding changes in product rep
 
 ### Updating an External Component Used in a Pre-SBE Repo
 
-When updating a component that is used in a repository which is built before source-build-externals during the product build (pre-SBE repo), please adhere to the following steps:
+A _Pre-SBE_ repo is a repo that is built before source-build-externals during the product build.
 
 > [!NOTE]
 >
-> You can view the current pre-SBE repos by running `dotnet msbuild repo-projects/source-build-externals.proj -target:ShowDependencyGraph /p:DotNetBuildSourceOnly=true` from the root of the product repo.
+> You can view the current pre-SBE repos by running `dotnet msbuild repo-projects/source-build-externals.proj -target:ShowDependencyGraph /p:DotNetBuildSourceOnly=true` from the root of the VMR.
+
+When updating a component that is used in a Pre-SBE repo, please adhere to the following steps:
 
 1. **Add the updated component**: Include the component with the updated version as a new submodule in source-build-externals named `<component>-<new-version>` (this new submodule should be separate from any previously existing version's submodule). Rename the component's old submodule to `<component>-<old-version>`. Also rename the old component's patches directory in `patches/` (if it exists) and the project file in `repo-projects/` to match the submodule name of `<component>-<old-version>`.
     - See [#276](https://github.com/dotnet/source-build-externals/pull/276) for an example.

--- a/README.md
+++ b/README.md
@@ -41,16 +41,6 @@ must be applied via [patches](patches). See [below](#patches) for more info on p
 
 ## Updating an External Component to a Newer Version
 
-When updating a component that is used in both Arcade and another target repository, follow these steps:
-
-1. **Add the updated component**: Include the component with the updated version as a new submodule in source-build-externals.
-2. **Update the target repository**: Allow the updated version to flow to the target repository and update the target repository to use this new version.
-3. **Build and release**: Perform a build and release the artifacts to update the n-1 (previous) artifacts for Arcade.
-4. **Update Arcade**: Update Arcade to use the new version of the component.
-5. **Clean up**: Remove the outdated component from source-build-externals.
-
-To update the component, follow these steps:
-
 1. Update the `src/<external_repo_dir>` to the desired sha
 
     ``` bash
@@ -77,6 +67,25 @@ To update the component, follow these steps:
 
 1. After the PR is merged to update a component, coordination is often needed in the darc dependency flows. The source-build-external update
 may need to flow in at the same time as the cooresponding changes in product repos which take a dependency on the new component version.
+
+### Updating an External Component Used in a Toolset Repo and in a Target Repo
+
+When updating a component that is used in a repository which is built before source-build-externals during the product build (toolset repos) and is used in a repo that is build after source-build-externals (target repos), please adhere to the following steps:
+
+> [!NOTE]
+>
+> Current toolset repositories are:
+> - [Arcade](https://github.com/dotnet/arcade)
+> - [Souce-build-reference-packages](https://github.com/dotnet/source-build-reference-packages/)
+> - [Cecil](https://github.com/dotnet/cecil)
+> - [Command-line-api](https://github.com/dotnet/command-line-api/)
+> - [Emsdk](https://github.com/dotnet/emsdk)
+
+1. **Add the updated component**: Include the component with the updated version as a new submodule in source-build-externals named `<component>-<new-version>` (this new submodule should be separate from any previously existing version's submodule). Rename the component's old submodule to `<component>-<old-version>`. Also rename the old component's patches directory in `patches/` (if it exists) and the project file in `repo-projects/` to match the submodule name of `<component>-<old-version>`.
+2. **Update the target repository**: Allow the updated version to flow to the target repository and update the target repository to use this new version.
+3. **Build and release**: Perform a build and release the artifacts to update the n-1 (previous) artifacts for the toolset repository.
+4. **Update the toolset repository**: Update the toolset repository to use the new version of the component.
+5. **Clean up**: Remove the outdated component from source-build-externals, the outdated component's patches directory in `patches/`, if applicable, and the project file in `repo-projects`. Rename the updated component's submodule to `<component>`. Also rename any existing patches directory in `patches/` and the respective project file in `repo-projects/` to match the submodule name, `<component>`.
 
 ## Patches
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ may need to flow in at the same time as the cooresponding changes in product rep
 
 ### Updating an External Component Used in a Toolset Repo and in a Target Repo
 
-When updating a component that is used in a repository which is built before source-build-externals during the product build (toolset repos) and is used in a repo that is build after source-build-externals (target repos), please adhere to the following steps:
+When updating a component that is used in a repository which is built before source-build-externals during the product build (toolset repos) and is used in a repo that is built after source-build-externals (target repos), please adhere to the following steps:
 
 > [!NOTE]
 >
 > Current toolset repositories are:
 > - [Arcade](https://github.com/dotnet/arcade)
-> - [Souce-build-reference-packages](https://github.com/dotnet/source-build-reference-packages/)
+> - [Source-build-reference-packages](https://github.com/dotnet/source-build-reference-packages/)
 > - [Cecil](https://github.com/dotnet/cecil)
 > - [Command-line-api](https://github.com/dotnet/command-line-api/)
 > - [Emsdk](https://github.com/dotnet/emsdk)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ must be applied via [patches](patches). See [below](#patches) for more info on p
 
 ## Updating an External Component to a Newer Version
 
+When updating a component that is used in both Arcade and another target repository, follow these steps:
+
+1. **Add the updated component**: Include the component with the updated version as a new submodule in source-build-externals.
+2. **Update the target repository**: Allow the updated version to flow to the target repository and update the target repository to use this new version.
+3. **Build and release**: Perform a build and release the artifacts to update the n-1 (previous) artifacts for Arcade.
+4. **Update Arcade**: Update Arcade to use the new version of the component.
+5. **Clean up**: Remove the outdated component from source-build-externals.
+
+To update the component, follow these steps:
+
 1. Update the `src/<external_repo_dir>` to the desired sha
 
     ``` bash

--- a/README.md
+++ b/README.md
@@ -68,23 +68,19 @@ must be applied via [patches](patches). See [below](#patches) for more info on p
 1. After the PR is merged to update a component, coordination is often needed in the darc dependency flows. The source-build-external update
 may need to flow in at the same time as the cooresponding changes in product repos which take a dependency on the new component version.
 
-### Updating an External Component Used in a Toolset Repo and in a Target Repo
+### Updating an External Component Used in a Pre-SBE Repo
 
-When updating a component that is used in a repository which is built before source-build-externals during the product build (toolset repos) and is used in a repo that is built after source-build-externals (target repos), please adhere to the following steps:
+When updating a component that is used in a repository which is built before source-build-externals during the product build (pre-SBE repo), please adhere to the following steps:
 
 > [!NOTE]
 >
-> Current toolset repositories are:
-> - [Arcade](https://github.com/dotnet/arcade)
-> - [Source-build-reference-packages](https://github.com/dotnet/source-build-reference-packages/)
-> - [Cecil](https://github.com/dotnet/cecil)
-> - [Command-line-api](https://github.com/dotnet/command-line-api/)
-> - [Emsdk](https://github.com/dotnet/emsdk)
+> You can view the current pre-SBE repos by running `dotnet msbuild repo-projects/source-build-externals.proj -target:ShowDependencyGraph /p:DotNetBuildSourceOnly=true` from the root of the product repo.
 
 1. **Add the updated component**: Include the component with the updated version as a new submodule in source-build-externals named `<component>-<new-version>` (this new submodule should be separate from any previously existing version's submodule). Rename the component's old submodule to `<component>-<old-version>`. Also rename the old component's patches directory in `patches/` (if it exists) and the project file in `repo-projects/` to match the submodule name of `<component>-<old-version>`.
-2. **Update the target repository**: Allow the updated version to flow to the target repository and update the target repository to use this new version.
-3. **Build and release**: Perform a build and release the artifacts to update the n-1 (previous) artifacts for the toolset repository.
-4. **Update the toolset repository**: Update the toolset repository to use the new version of the component.
+    - See [#276](https://github.com/dotnet/source-build-externals/pull/276) for an example.
+2. **Update post-SBE repositories (if applicable)**: If your dependency is also in a repo that is built after SBE, allow the updated version to flow to the post-SBE repository and update the post-SBE repository to use this new version.
+3. **Build and release**: Perform a build and release the artifacts to update the n-1 (previous) artifacts for the pre-SBE repository.
+4. **Update the pre-SBE repository**: Update the pre-SBE repository to use the new version of the component.
 5. **Clean up**: Remove the outdated component from source-build-externals, the outdated component's patches directory in `patches/`, if applicable, and the project file in `repo-projects`. Rename the updated component's submodule to `<component>`. Also rename any existing patches directory in `patches/` and the respective project file in `repo-projects/` to match the submodule name, `<component>`.
 
 ## Patches


### PR DESCRIPTION
This Pull Request implements the suggestions from [this discussion](https://github.com/dotnet/source-build-externals/pull/276#discussion_r1518228886) which pointed out the necessity of adding the steps detailed in [this issue comment](https://github.com/dotnet/source-build/issues/4191#issuecomment-1984552053) to the repo's REDME.

More specifically, the steps discuss which actions to take when updating an SBE component that is in a target repo and in Arcade.