### PR TITLE
Remove explicit handling of git commits

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -67,16 +67,6 @@
     <EnvironmentVariables Include="OfficialBuildId=$(OfficialBuildId)" />
     <EnvironmentVariables Include="BUILD_BUILDNUMBER=$(OfficialBuildId)" />
 
-    <!-- Give build access to commit info without necessarily requiring git queries. -->
-    <EnvironmentVariables Include="GitCommitCount=$(GitCommitCount)" />
-    <EnvironmentVariables Include="GitCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GitInfoCommitHash=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="SourceRevisionId=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryCommit=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="COMMIT_SHA=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="GIT_COMMIT=$(GitCommitHash)" Condition="'$(GitCommitHash)' != ''" />
-    <EnvironmentVariables Include="RepositoryType=Git" />
-
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
     
     <!-- Disable restoring transitive aspnetcore and windowsdesktop targeting packs to avoid unnecessary dependencies. -->


### PR DESCRIPTION
Rely on submodules/projects to find and use the correct git commit automagically. This is already handled by sourcelink, which uses full git metadata if avaialable or minimal git metadata otherwise.

In fact, it doesn't look like any of the submodules/projects here use git commit info at all, other than humanizer.

src/humanizer/NuSpecs/Humanizer.Core.nuspec includes a `<repository>` element with a `$RepositoryCommit$` variablea but the nupsec inside the built humanizer nupkg doesn't include this element either before or after this change.

[1] https://github.com/dotnet/sourcelink/tree/main/docs#minimal-git-repository-metadata