### PR TITLE
Stop buildinging NewtonSoft.Json for NetStandard1.*

### DIFF
--- a/repo-projects/newtonsoft-json.proj
+++ b/repo-projects/newtonsoft-json.proj
@@ -4,7 +4,7 @@
   <!--The Library Frameworks was added to environment variables so as to override the frameworks in newtonsoft csproj-->
   <!--The semicolons were added with encoding so as to avoid conflicts in MSBuild shell-->
   <ItemGroup>
-    <EnvironmentVariables Include="LibraryFrameworks=netstandard1.0%3Bnetstandard1.3%3Bnetstandard2.0" />
+    <EnvironmentVariables Include="LibraryFrameworks=netstandard2.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4482

[Test Build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2503206&view=results) (Microsoft internal link)