### PR TITLE
Eliminate netstandard1.* references from application-insights

### DIFF
--- a/patches/application-insights/0002-Update-System.Diagnostics.DiagnosticSource-to-elimin.patch
+++ b/patches/application-insights/0002-Update-System.Diagnostics.DiagnosticSource-to-elimin.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael Simons <msimons@microsoft.com>
+Date: Fri, 26 Jul 2024 18:03:44 +0000
+Subject: [PATCH] Update System.Diagnostics.DiagnosticSource to eliminate
+ NetStandard1.* dependencies
+
+---
+ Directory.Build.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Directory.Build.props b/Directory.Build.props
+index da394914..4faf4d07 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -13,7 +13,7 @@
+   </PropertyGroup>
+ 
+   <PropertyGroup Label="Package versions for System.Diagnostics.DiagnosticSource">
+-    <SystemDiagnosticsDiagnosticSourcePkgVer>5.0.0</SystemDiagnosticsDiagnosticSourcePkgVer>
++    <SystemDiagnosticsDiagnosticSourcePkgVer>8.0.0</SystemDiagnosticsDiagnosticSourcePkgVer>
+     <SystemDiagnosticsDiagnosticSourcePkgVer Condition="'$(Redfield)' == 'True'">4.7.0</SystemDiagnosticsDiagnosticSourcePkgVer>
+   </PropertyGroup>
+ 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4482

I plan to upstream this change once verified.

[Test Build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2503270&view=results) (Microsoft internal link)