### PR TITLE
Update xunit to 2.9.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MSBuildLocatorReleaseVersion>1.6.10</MSBuildLocatorReleaseVersion>
     <SolutionPersistenceVersion>1.0.6</SolutionPersistenceVersion>
     <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
-    <XunitReleaseVersion>2.4.2</XunitReleaseVersion>
+    <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>

--- a/patches/xunit/0001-Patching.patch
+++ b/patches/xunit/0001-Patching.patch
@@ -1,43 +1,10 @@
-From cf6cbdbed67c5dcc36892489ab80778e4cd6033a Mon Sep 17 00:00:00 2001
-From: Matt Mitchell <mmitche@microsoft.com>
-Date: Tue, 18 Jul 2023 12:32:15 -0700
-Subject: [PATCH] Patching
-
----
- global.json                                   |  5 ---
- src/Directory.Build.props                     | 11 ++---
- src/Directory.Build.targets                   | 21 ---------
- src/xunit.assert/xunit.assert.csproj          | 13 +-----
- src/xunit.core/xunit.core.csproj              |  2 +-
- src/xunit.execution/xunit.execution.csproj    |  4 +-
- src/xunit.extensibility.core.nuspec           | 17 ++------
- src/xunit.extensibility.execution.nuspec      | 14 ++----
- .../xunit.runner.assemblies.csproj            |  2 +-
- src/xunit.runner.utility.nuspec               | 43 ++-----------------
- .../xunit.runner.utility.csproj               | 12 ++----
- xunit-notests.slnf                            | 10 +++++
- 12 files changed, 33 insertions(+), 121 deletions(-)
- delete mode 100644 global.json
- create mode 100644 xunit-notests.slnf
-
-diff --git a/global.json b/global.json
-deleted file mode 100644
-index ebd1966e..00000000
---- a/global.json
-+++ /dev/null
-@@ -1,5 +0,0 @@
--{
--  "msbuild-sdks": {
--    "MSBuild.Sdk.Extras": "3.0.38"
--  }
--}
 diff --git a/src/Directory.Build.props b/src/Directory.Build.props
-index 95cabfab..42a4ee85 100644
+index a2668bac..2a9f85bf 100644
 --- a/src/Directory.Build.props
 +++ b/src/Directory.Build.props
-@@ -22,18 +22,13 @@
-     <TargetPlatformMinVersion Condition=" '$(TargetFramework)' == 'uap10.0' ">10.0.16299.0</TargetPlatformMinVersion>
-     <TargetPlatformVersion Condition=" '$(TargetFramework)' == 'uap10.0' ">10.0.19041.0</TargetPlatformVersion>
+@@ -24,18 +24,13 @@
+     <RootNamespace>Xunit</RootNamespace>
+     <SignAssembly>true</SignAssembly>
      <WarningsAsErrors>true</WarningsAsErrors>
 +    <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
 +    <AssemblyFileVersion>$(PackageVersion)</AssemblyFileVersion>
@@ -49,8 +16,8 @@ index 95cabfab..42a4ee85 100644
    </ItemGroup>
  
 -  <ItemGroup>
--    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
--    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.108">
+-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.143">
 -      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 -      <PrivateAssets>all</PrivateAssets>
 -    </PackageReference>
@@ -58,10 +25,10 @@ index 95cabfab..42a4ee85 100644
 -
  </Project>
 diff --git a/src/Directory.Build.targets b/src/Directory.Build.targets
-index 87c4ea80..7fdf2a3d 100644
+index 819c97c3..7fdf2a3d 100644
 --- a/src/Directory.Build.targets
 +++ b/src/Directory.Build.targets
-@@ -7,25 +7,4 @@
+@@ -7,34 +7,4 @@
      <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.0</RuntimeFrameworkVersion>
      <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
    </PropertyGroup>
@@ -79,24 +46,38 @@ index 87c4ea80..7fdf2a3d 100644
 -
 -  <Target Name="UpdateNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
 -    <PropertyGroup>
+-      <SignedPath />
+-      <SignedPath Condition=" '$(SIGN_APP_SECRET)' != '' ">signed\</SignedPath>
+-      <!-- Local builds should have a '-dev' suffix on the build number -->
+-      <PrereleaseSuffix Condition=" '$(GITHUB_ACTIONS)' != 'true' ">-dev</PrereleaseSuffix>
 -      <!-- Never put the Git hash in the package version -->
--      <PackageVersion>$(BuildVersionSimple)$(PrereleaseVersion)</PackageVersion>
+-      <PackageVersion>$(BuildVersionSimple)$(PrereleaseVersion)$(PrereleaseSuffix)</PackageVersion>
 -      <!-- Pass through values we don't know ahead of time for any hand-crafted .nuspec files -->
--      <NuspecProperties>PackageVersion=$(PackageVersion);GitCommitId=$(GitCommitId);Configuration=$(Configuration)</NuspecProperties>
+-      <NuspecProperties>
+-        Configuration=$(Configuration);
+-        GitCommitId=$(GitCommitId);
+-        PackageVersion=$(PackageVersion);
+-        SignedPath=$(SignedPath);
+-      </NuspecProperties>
 -    </PropertyGroup>
 -  </Target>
 -
  </Project>
 diff --git a/src/xunit.assert/xunit.assert.csproj b/src/xunit.assert/xunit.assert.csproj
-index 40e37a96..29a41b43 100644
+index 0fdde3a4..15c5c49c 100644
 --- a/src/xunit.assert/xunit.assert.csproj
 +++ b/src/xunit.assert/xunit.assert.csproj
-@@ -4,18 +4,7 @@
-     <DefineConstants>$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
+@@ -1,22 +1,11 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+ 
+   <PropertyGroup>
+-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.1' ">$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
++    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(DefineConstants);XUNIT_NULLABLE</DefineConstants>
+     <DefineConstants Condition=" '$(TargetFramework)' == 'net6.0' ">$(DefineConstants);XUNIT_IMMUTABLE_COLLECTIONS;XUNIT_NULLABLE;XUNIT_SPAN</DefineConstants>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
      <Nullable>enable</Nullable>
--    <TargetFramework>netstandard1.1</TargetFramework>
-+    <TargetFramework>netstandard2.0</TargetFramework>
+-    <TargetFrameworks>netstandard1.1;net6.0</TargetFrameworks>
++    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
    </PropertyGroup>
  
 -  <ItemGroup>
@@ -107,17 +88,17 @@ index 40e37a96..29a41b43 100644
 -  </ItemGroup>
 -
 -  <ItemGroup>
--    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[5.0.0]" />
+-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[8.0.5]" />
 -  </ItemGroup>
 -
  </Project>
 diff --git a/src/xunit.core/xunit.core.csproj b/src/xunit.core/xunit.core.csproj
-index acbc33ca..2ea18abc 100644
+index 058a174b..e6c63c94 100644
 --- a/src/xunit.core/xunit.core.csproj
 +++ b/src/xunit.core/xunit.core.csproj
 @@ -3,7 +3,7 @@
    <PropertyGroup>
-     <DefineConstants>$(DefineConstants);XUNIT_FRAMEWORK</DefineConstants>
+     <DefineConstants>$(DefineConstants);XUNIT_ARGUMENTFORMATTER_PRIVATE;XUNIT_FRAMEWORK</DefineConstants>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
 -    <TargetFramework>netstandard1.1</TargetFramework>
 +    <TargetFramework>netstandard2.0</TargetFramework>
@@ -125,7 +106,7 @@ index acbc33ca..2ea18abc 100644
  
    <ItemGroup>
 diff --git a/src/xunit.execution/xunit.execution.csproj b/src/xunit.execution/xunit.execution.csproj
-index 43174d1f..b65b4e60 100644
+index fa959255..b8732cb3 100644
 --- a/src/xunit.execution/xunit.execution.csproj
 +++ b/src/xunit.execution/xunit.execution.csproj
 @@ -2,11 +2,11 @@
@@ -134,7 +115,7 @@ index 43174d1f..b65b4e60 100644
      <AssemblyName Condition=" '$(TargetFramework)' == 'net452' ">xunit.execution.desktop</AssemblyName>
 -    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard1.1' ">xunit.execution.dotnet</AssemblyName>
 +    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard2.0' ">xunit.execution.dotnet</AssemblyName>
-     <DefineConstants>$(DefineConstants);XUNIT_FRAMEWORK</DefineConstants>
+     <DefineConstants>$(DefineConstants);XUNIT_ARGUMENTFORMATTER_PRIVATE;XUNIT_FRAMEWORK</DefineConstants>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
      <RootNamespace>Xunit.Sdk</RootNamespace>
 -    <TargetFrameworks>net452;netstandard1.1</TargetFrameworks>
@@ -143,10 +124,10 @@ index 43174d1f..b65b4e60 100644
  
    <ItemGroup>
 diff --git a/src/xunit.extensibility.core.nuspec b/src/xunit.extensibility.core.nuspec
-index 4063c36e..7c9247c0 100644
+index 8b3fac36..02076906 100644
 --- a/src/xunit.extensibility.core.nuspec
 +++ b/src/xunit.extensibility.core.nuspec
-@@ -16,11 +16,8 @@
+@@ -18,14 +18,8 @@
        <reference file="xunit.core.xml" />
      </references>
      <dependencies>
@@ -155,32 +136,34 @@ index 4063c36e..7c9247c0 100644
 -      </group>
 -      <group targetFramework="netstandard1.1">
 -        <dependency id="NETStandard.Library" version="1.6.1" />
-+      <group targetFramework="netstandard2.0">
+-        <dependency id="xunit.abstractions" version="2.0.3" />
+-      </group>
+       <group targetFramework="netstandard2.0">
 +        <dependency id="NETStandard.Library" version="2.0.3" />
          <dependency id="xunit.abstractions" version="2.0.3" />
        </group>
      </dependencies>
-@@ -28,13 +25,7 @@
-   <files>
+@@ -35,13 +29,7 @@
      <file target="_content\" src="..\tools\media\logo-128-transparent.png" />
+     <file target="_content\" src="..\README.md" />
  
--    <file src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.dll"                  target="lib\net452\" />
--    <file src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.dll.tdnet"            target="lib\net452\" />
--    <file src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.xml"                  target="lib\net452\" />
--    <file src="xunit.runner.tdnet\bin\$Configuration$\net452\xunit.runner.tdnet.dll"          target="lib\net452\" />
--    <file src="xunit.runner.tdnet\bin\$Configuration$\net452\xunit.runner.utility.net452.dll" target="lib\net452\" />
+-    <file target="lib\net452\" src="xunit.core\bin\$Configuration$\netstandard1.1\$SignedPath$xunit.core.dll" />
+-    <file target="lib\net452\" src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.dll.tdnet" />
+-    <file target="lib\net452\" src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.xml" />
+-    <file target="lib\net452\" src="xunit.runner.tdnet\bin\$Configuration$\net452\$SignedPath$xunit.runner.tdnet.dll" />
+-    <file target="lib\net452\" src="xunit.runner.utility\bin\$Configuration$\net452\$SignedPath$xunit.runner.utility.net452.dll" />
 -
--    <file src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.dll" target="lib\netstandard1.1\" />
--    <file src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.xml" target="lib\netstandard1.1\" />
+-    <file target="lib\netstandard1.1\" src="xunit.core\bin\$Configuration$\netstandard1.1\$SignedPath$xunit.core.dll" />
+-    <file target="lib\netstandard1.1\" src="xunit.core\bin\$Configuration$\netstandard1.1\xunit.core.xml" />
 +    <file src="xunit.core\bin\$Configuration$\netstandard2.0\xunit.core.dll" target="lib\netstandard2.0\" />
 +    <file src="xunit.core\bin\$Configuration$\netstandard2.0\xunit.core.xml" target="lib\netstandard2.0\" />
    </files>
  </package>
 diff --git a/src/xunit.extensibility.execution.nuspec b/src/xunit.extensibility.execution.nuspec
-index 3c5039fc..01f71f1c 100644
+index 208dcc6d..011c4109 100644
 --- a/src/xunit.extensibility.execution.nuspec
 +++ b/src/xunit.extensibility.execution.nuspec
-@@ -13,11 +13,8 @@
+@@ -15,14 +15,8 @@
      <copyright>Copyright (C) .NET Foundation</copyright>
      <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />
      <dependencies>
@@ -189,27 +172,30 @@ index 3c5039fc..01f71f1c 100644
 -      </group>
 -      <group targetFramework="netstandard1.1">
 -        <dependency id="NETStandard.Library" version="1.6.1" />
-+      <group targetFramework="netstandard2.0">
+-        <dependency id="xunit.extensibility.core" version="[$PackageVersion$]" />
+-      </group>
+       <group targetFramework="netstandard2.0">
 +        <dependency id="NETStandard.Library" version="2.0.3" />
          <dependency id="xunit.extensibility.core" version="[$PackageVersion$]" />
        </group>
      </dependencies>
-@@ -25,10 +22,7 @@
-   <files>
+@@ -32,10 +26,7 @@
      <file target="_content\" src="..\tools\media\logo-128-transparent.png" />
+     <file target="_content\" src="..\README.md" />
  
--    <file src="xunit.execution\bin\$Configuration$\net452\xunit.execution.desktop.dll" target="lib\net452\" />
--    <file src="xunit.execution\bin\$Configuration$\net452\xunit.execution.desktop.xml" target="lib\net452\" />
+-    <file target="lib\net452\" src="xunit.execution\bin\$Configuration$\net452\$SignedPath$xunit.execution.desktop.dll" />
+-    <file target="lib\net452\" src="xunit.execution\bin\$Configuration$\net452\xunit.execution.desktop.xml" />
 -
--    <file src="xunit.execution\bin\$Configuration$\netstandard1.1\xunit.execution.dotnet.dll" target="lib\netstandard1.1\" />
--    <file src="xunit.execution\bin\$Configuration$\netstandard1.1\xunit.execution.dotnet.xml" target="lib\netstandard1.1\" />
+-    <file target="lib\netstandard1.1\" src="xunit.execution\bin\$Configuration$\netstandard1.1\$SignedPath$xunit.execution.dotnet.dll" />
+-    <file target="lib\netstandard1.1\" src="xunit.execution\bin\$Configuration$\netstandard1.1\xunit.execution.dotnet.xml" />
 +    <file src="xunit.execution\bin\$Configuration$\netstandard2.0\xunit.execution.dotnet.dll" target="lib\netstandard2.0\" />
 +    <file src="xunit.execution\bin\$Configuration$\netstandard2.0\xunit.execution.dotnet.xml" target="lib\netstandard2.0\" />
    </files>
- </package>
+-</package>
++</package>
 \ No newline at end of file
 diff --git a/src/xunit.runner.assemblies/xunit.runner.assemblies.csproj b/src/xunit.runner.assemblies/xunit.runner.assemblies.csproj
-index 5ca7d4c9..8f530055 100644
+index bf4ce9bd..c6e272d6 100644
 --- a/src/xunit.runner.assemblies/xunit.runner.assemblies.csproj
 +++ b/src/xunit.runner.assemblies/xunit.runner.assemblies.csproj
 @@ -3,7 +3,7 @@
@@ -222,10 +208,10 @@ index 5ca7d4c9..8f530055 100644
  
    <ItemGroup>
 diff --git a/src/xunit.runner.utility.nuspec b/src/xunit.runner.utility.nuspec
-index eba39303..930d81a5 100644
+index dc360934..9a9b80ce 100644
 --- a/src/xunit.runner.utility.nuspec
 +++ b/src/xunit.runner.utility.nuspec
-@@ -13,27 +13,8 @@
+@@ -15,33 +15,11 @@
      <copyright>Copyright (C) .NET Foundation</copyright>
      <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />
      <dependencies>
@@ -241,53 +227,53 @@ index eba39303..930d81a5 100644
 -      </group>
 -      <group targetFramework="netstandard1.5">
 -        <dependency id="NETStandard.Library" version="1.6.1" />
--        <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
+-        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
 -        <dependency id="xunit.abstractions" version="2.0.3" />
 -      </group>
+       <group targetFramework="netstandard2.0">
++        <dependency id="NETStandard.Library" version="2.0.3" />
+         <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
+         <dependency id="xunit.abstractions" version="2.0.3" />
+       </group>
 -      <group targetFramework="netcoreapp1.0">
 -        <dependency id="NETStandard.Library" version="1.6.0" />
 -        <dependency id="System.Runtime.Loader" version="4.0.0" />
 -        <dependency id="xunit.abstractions" version="2.0.3" />
 -      </group>
--      <group targetFramework="uap10.0">
-+      <group targetFramework="netstandard2.0">
-+        <dependency id="NETStandard.Library" version="2.0.3" />
-         <dependency id="xunit.abstractions" version="2.0.3" />
-       </group>
+-      <group targetFramework="netcoreapp2.0">
+-        <dependency id="xunit.abstractions" version="2.0.3" />
+-      </group>
      </dependencies>
-@@ -41,23 +22,7 @@
-   <files>
+   </metadata>
+   <!-- Remember to update tools\builder\targets\SignAssemblies.cs when assemblies are added or removed -->
+@@ -49,19 +27,7 @@
      <file target="_content\" src="..\tools\media\logo-128-transparent.png" />
+     <file target="_content\" src="..\README.md" />
  
--    <file src="xunit.runner.utility\bin\$Configuration$\net35\xunit.runner.utility.net35.dll" target="lib\net35\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\net35\xunit.runner.utility.net35.xml" target="lib\net35\" />
+-    <file target="lib\net35\" src="xunit.runner.utility\bin\$Configuration$\net35\$SignedPath$xunit.runner.utility.net35.dll" />
+-    <file target="lib\net35\" src="xunit.runner.utility\bin\$Configuration$\net35\xunit.runner.utility.net35.xml" />
 -
--    <file src="xunit.runner.utility\bin\$Configuration$\net452\xunit.runner.utility.net452.dll" target="lib\net452\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\net452\xunit.runner.utility.net452.xml" target="lib\net452\" />
+-    <file target="lib\net452\" src="xunit.runner.utility\bin\$Configuration$\net452\$SignedPath$xunit.runner.utility.net452.dll" />
+-    <file target="lib\net452\" src="xunit.runner.utility\bin\$Configuration$\net452\xunit.runner.utility.net452.xml" />
 -
--    <file src="xunit.runner.utility\bin\$Configuration$\netstandard1.1\xunit.runner.utility.netstandard11.dll" target="lib\netstandard1.1\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\netstandard1.1\xunit.runner.utility.netstandard11.xml" target="lib\netstandard1.1\" />
+-    <file target="lib\netstandard1.1\" src="xunit.runner.utility\bin\$Configuration$\netstandard1.1\$SignedPath$xunit.runner.utility.netstandard11.dll" />
+-    <file target="lib\netstandard1.1\" src="xunit.runner.utility\bin\$Configuration$\netstandard1.1\xunit.runner.utility.netstandard11.xml" />
 -
--    <file src="xunit.runner.utility\bin\$Configuration$\netstandard1.5\xunit.runner.utility.netstandard15.dll" target="lib\netstandard1.5\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\netstandard1.5\xunit.runner.utility.netstandard15.xml" target="lib\netstandard1.5\" />
+-    <file target="lib\netstandard1.5\" src="xunit.runner.utility\bin\$Configuration$\netstandard1.5\$SignedPath$xunit.runner.utility.netstandard15.dll" />
+-    <file target="lib\netstandard1.5\" src="xunit.runner.utility\bin\$Configuration$\netstandard1.5\xunit.runner.utility.netstandard15.xml" />
 -
--    <file src="xunit.runner.utility\bin\$Configuration$\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" target="lib\netcoreapp1.0\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\netcoreapp1.0\xunit.runner.utility.netcoreapp10.xml" target="lib\netcoreapp1.0\" />
--
--    <file src="xunit.runner.utility\bin\$Configuration$\uap10.0\xunit.runner.utility.uwp10.dll" target="lib\uap10.0\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\uap10.0\xunit.runner.utility.uwp10.xml" target="lib\uap10.0\" />
--    <file src="xunit.runner.utility\bin\$Configuration$\uap10.0\xunit.runner.utility.uwp10.pri" target="lib\uap10.0\" />
+-    <file target="lib\netcoreapp1.0\" src="xunit.runner.utility\bin\$Configuration$\netcoreapp1.0\$SignedPath$xunit.runner.utility.netcoreapp10.dll" />
+-    <file target="lib\netcoreapp1.0\" src="xunit.runner.utility\bin\$Configuration$\netcoreapp1.0\xunit.runner.utility.netcoreapp10.xml" />
 +    <file src="xunit.runner.utility\bin\$Configuration$\netstandard2.0\xunit.runner.utility.netstandard20.dll" target="lib\netstandard2.0\" />
 +    <file src="xunit.runner.utility\bin\$Configuration$\netstandard2.0\xunit.runner.utility.netstandard20.xml" target="lib\netstandard2.0\" />
    </files>
  </package>
-\ No newline at end of file
 diff --git a/src/xunit.runner.utility/xunit.runner.utility.csproj b/src/xunit.runner.utility/xunit.runner.utility.csproj
-index 5f0cb1a8..6293be58 100644
+index 46d4a44f..5fa5cc58 100644
 --- a/src/xunit.runner.utility/xunit.runner.utility.csproj
 +++ b/src/xunit.runner.utility/xunit.runner.utility.csproj
-@@ -1,16 +1,10 @@
--﻿<Project Sdk="MSBuild.Sdk.Extras">
+@@ -1,14 +1,10 @@
+-<Project Sdk="Microsoft.NET.Sdk">
 +﻿<Project Sdk="Microsoft.NET.Sdk">
  
    <PropertyGroup>
@@ -296,12 +282,10 @@ index 5f0cb1a8..6293be58 100644
 -    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard1.1' ">xunit.runner.utility.netstandard11</AssemblyName>
 -    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard1.5' ">xunit.runner.utility.netstandard15</AssemblyName>
 -    <AssemblyName Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">xunit.runner.utility.netcoreapp10</AssemblyName>
--    <AssemblyName Condition=" '$(TargetFramework)' == 'uap10.0' ">xunit.runner.utility.uwp10</AssemblyName>
--    <DefineConstants Condition=" '$(TargetFramework)' == 'uap10.0' ">$(DefineConstants);WINDOWS_UAP</DefineConstants>
 +    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard2.0' ">xunit.runner.utility.netstandard20</AssemblyName>
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
      <RootNamespace>Xunit</RootNamespace>
--    <TargetFrameworks>net35;net452;netstandard1.1;netstandard1.5;netcoreapp1.0;uap10.0</TargetFrameworks>
+-    <TargetFrameworks>net35;net452;netstandard1.1;netstandard1.5;netcoreapp1.0</TargetFrameworks>
 +    <TargetFrameworks>netstandard2.0</TargetFrameworks>
    </PropertyGroup>
  
@@ -323,6 +307,3 @@ index 00000000..41d03844
 +  }
 +}
 \ No newline at end of file
--- 
-2.41.0.windows.2
-


### PR DESCRIPTION
## Description

Updates the xunit version following https://github.com/dotnet/arcade/pull/15170

## PR Checklist

If you are upgrading the version of a repo submodule, please follow this
checklist:

- [ ] Provide a link to an issue in the consuming repo describing the need for
the upgrade. Both this PR and the PR doing the upgrade in the consuming repo
should link to that issue.
- [ ] Have you done your due diligence to ensure the upgrade can be completed
in the consuming repo in a timely manner? If consuming the dependency flow of
this update takes a long time or needs to be backed out, it may require the
reversion of the upgrade in this PR. That's something we want to avoid.
- [ ] When consuming the dependency flow from this repo for the purposes of a
version upgrade, consider using a separate PR or at least changing the title of
the dependency flow PR to accurately reflect the purpose of the change. Seeing
a PR named "Upgrade IdentityModel to 8.0.1", for example, provides better
clarity than "Update dependencies from dotnet/source-build-externals".
