### PR TITLE
Update vs-solutionpersistence to 1.0.9

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <CssParserReleaseVersionSuffix>20230414.1</CssParserReleaseVersionSuffix>
     <HumanizerReleaseVersion>2.14.1</HumanizerReleaseVersion>
     <MSBuildLocatorReleaseVersion>1.6.10</MSBuildLocatorReleaseVersion>
-    <SolutionPersistenceVersion>1.0.6</SolutionPersistenceVersion>
+    <SolutionPersistenceVersion>1.0.9</SolutionPersistenceVersion>
     <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
     <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>


### PR DESCRIPTION
```
 .packages/microsoft.dotnet.arcade.sdk/9.0.0-beta.24509.3/tools/SourceBuild/AfterSourceBuild.proj#L81

.packages/microsoft.dotnet.arcade.sdk/9.0.0-beta.24509.3/tools/SourceBuild/AfterSourceBuild.proj(81,5): error : (NETCORE_ENGINEERING_TELEMETRY=AfterSourceBuild) 1 new pre-builts discovered! Detailed usage report can be found at /__w/1/s/artifacts/sb/prebuilt-report/baseline-comparison.xml.
See https://aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them.
Package IDs are:
Microsoft.VisualStudio.SolutionPersistence.1.0.9
```

error from https://github.com/dotnet/msbuild/pull/10794