### PR TITLE
Remove System.Reflection.TypeExtensions from xunit patch

### DIFF
--- a/patches/xunit/0001-Patching.patch
+++ b/patches/xunit/0001-Patching.patch
@@ -211,7 +211,7 @@ diff --git a/src/xunit.runner.utility.nuspec b/src/xunit.runner.utility.nuspec
 index dc360934..9a9b80ce 100644
 --- a/src/xunit.runner.utility.nuspec
 +++ b/src/xunit.runner.utility.nuspec
-@@ -15,33 +15,11 @@
+@@ -15,31 +15,8 @@
      <copyright>Copyright (C) .NET Foundation</copyright>
      <repository type="git" url="https://github.com/xunit/xunit" commit="$GitCommitId$" />
      <dependencies>
@@ -231,22 +231,20 @@ index dc360934..9a9b80ce 100644
 -        <dependency id="xunit.abstractions" version="2.0.3" />
 -      </group>
        <group targetFramework="netstandard2.0">
-+        <dependency id="NETStandard.Library" version="2.0.3" />
-         <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
-         <dependency id="xunit.abstractions" version="2.0.3" />
-       </group>
+-        <dependency id="System.Reflection.TypeExtensions" version="4.7.0" />
+-        <dependency id="xunit.abstractions" version="2.0.3" />
+-      </group>
 -      <group targetFramework="netcoreapp1.0">
 -        <dependency id="NETStandard.Library" version="1.6.0" />
 -        <dependency id="System.Runtime.Loader" version="4.0.0" />
 -        <dependency id="xunit.abstractions" version="2.0.3" />
 -      </group>
 -      <group targetFramework="netcoreapp2.0">
--        <dependency id="xunit.abstractions" version="2.0.3" />
--      </group>
++        <dependency id="NETStandard.Library" version="2.0.3" />
+         <dependency id="xunit.abstractions" version="2.0.3" />
+       </group>
      </dependencies>
-   </metadata>
-   <!-- Remember to update tools\builder\targets\SignAssemblies.cs when assemblies are added or removed -->
-@@ -49,19 +27,7 @@
+@@ -49,19 +26,7 @@
      <file target="_content\" src="..\tools\media\logo-128-transparent.png" />
      <file target="_content\" src="..\README.md" />
  


### PR DESCRIPTION
This was accidentally missed in https://github.com/dotnet/source-build-externals/pull/391

## Description

## PR Checklist

If you are upgrading the version of a repo submodule, please follow this
checklist:

- [ ] Provide a link to an issue in the consuming repo describing the need for
the upgrade. Both this PR and the PR doing the upgrade in the consuming repo
should link to that issue.
- [ ] Have you done your due diligence to ensure the upgrade can be completed
in the consuming repo in a timely manner? If consuming the dependency flow of
this update takes a long time or needs to be backed out, it may require the
reversion of the upgrade in this PR. That's something we want to avoid.
- [ ] When consuming the dependency flow from this repo for the purposes of a
version upgrade, consider using a separate PR or at least changing the title of
the dependency flow PR to accurately reflect the purpose of the change. Seeing
a PR named "Upgrade IdentityModel to 8.0.1", for example, provides better
clarity than "Update dependencies from dotnet/source-build-externals".
