### PR TITLE
Update vs-solutionpersistence to 1.0.26

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <CssParserReleaseVersionSuffix>20230414.1</CssParserReleaseVersionSuffix>
     <HumanizerReleaseVersion>2.14.1</HumanizerReleaseVersion>
     <MSBuildLocatorReleaseVersion>1.6.10</MSBuildLocatorReleaseVersion>
-    <SolutionPersistenceVersion>1.0.23</SolutionPersistenceVersion>
+    <SolutionPersistenceVersion>1.0.26</SolutionPersistenceVersion>
     <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
     <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>


### PR DESCRIPTION
this has a fix for `dotnet sln remove` command (which isn't yet switched to vs-solutionpersistence)

@edvilme 