### PR TITLE
Workaround CS7034 build break

### DIFF
--- a/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
+++ b/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
@@ -5,6 +5,13 @@
     <OutputPath>$(XPlatTasksBinDir)</OutputPath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Default assembly version causes CS7034. Assembly info is not necessary given this
+         msbuild task assembly is for build only purposes. -->
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <Deterministic>False</Deterministic>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />


### PR DESCRIPTION
Changes in https://github.com/dotnet/source-build-externals/pull/404 caused a build break.

  `/mnt/vss/_work/1/s/artifacts/sb/src/artifacts/obj/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Release/Microsoft.DotNet.SourceBuild.Tasks.XPlat.AssemblyInfo.cs(15,59): error CS7035: The specified version string '10.0.560201.0' does not conform to the recommended format - major.minor.build.revision [/mnt/vss/_work/1/s/artifacts/sb/src/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj]`


I disabled `GenerateAssemblyInfo` on the tasks project since it doesn't seem necessary for a msbuild task assembly used within the build.
