### PR TITLE
Update humanizer to target net10.0

### DIFF
--- a/patches/humanizer/0001-Tfm-updates-and-eliminate-prebuilts.patch
+++ b/patches/humanizer/0001-Tfm-updates-and-eliminate-prebuilts.patch
@@ -71,7 +71,7 @@ index a69e3a94..5f20c850 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\af\*.*" target="lib\netstandard1.0\af" />
      <file src="Humanizer\bin\Release\netstandard2.0\af\*.*" target="lib\netstandard2.0\af" />
 -    <file src="Humanizer\bin\Release\net6.0\af\*.*" target="lib\net6.0\af" />
-+    <file src="Humanizer\bin\Release\net9.0\af\*.*" target="lib\net9.0\af" />
++    <file src="Humanizer\bin\Release\net10.0\af\*.*" target="lib\net10.0\af" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -87,7 +87,7 @@ index 3abb6425..228e1b00 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ar\*.*" target="lib\netstandard1.0\ar" />
      <file src="Humanizer\bin\Release\netstandard2.0\ar\*.*" target="lib\netstandard2.0\ar" />
 -    <file src="Humanizer\bin\Release\net6.0\ar\*.*" target="lib\net6.0\ar" />
-+    <file src="Humanizer\bin\Release\net9.0\ar\*.*" target="lib\net9.0\ar" />
++    <file src="Humanizer\bin\Release\net10.0\ar\*.*" target="lib\net10.0\ar" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -103,7 +103,7 @@ index d6c4a004..6dabb04f 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\az\*.*" target="lib\netstandard1.0\az" />
      <file src="Humanizer\bin\Release\netstandard2.0\az\*.*" target="lib\netstandard2.0\az" />
 -    <file src="Humanizer\bin\Release\net6.0\az\*.*" target="lib\net6.0\az" />
-+    <file src="Humanizer\bin\Release\net9.0\az\*.*" target="lib\net9.0\az" />
++    <file src="Humanizer\bin\Release\net10.0\az\*.*" target="lib\net10.0\az" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -119,7 +119,7 @@ index 93924d00..9fe91384 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\bg\*.*" target="lib\netstandard1.0\bg" />
      <file src="Humanizer\bin\Release\netstandard2.0\bg\*.*" target="lib\netstandard2.0\bg" />
 -    <file src="Humanizer\bin\Release\net6.0\bg\*.*" target="lib\net6.0\bg" />
-+    <file src="Humanizer\bin\Release\net9.0\bg\*.*" target="lib\net9.0\bg" />
++    <file src="Humanizer\bin\Release\net10.0\bg\*.*" target="lib\net10.0\bg" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -135,7 +135,7 @@ index 27585ce6..a1021509 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\bn-BD\*.*" target="lib\netstandard1.0\bn-BD" />
      <file src="Humanizer\bin\Release\netstandard2.0\bn-BD\*.*" target="lib\netstandard2.0\bn-BD" />
 -    <file src="Humanizer\bin\Release\net6.0\bn-BD\*.*" target="lib\net6.0\bn-BD" />
-+    <file src="Humanizer\bin\Release\net9.0\bn-BD\*.*" target="lib\net9.0\bn-BD" />
++    <file src="Humanizer\bin\Release\net10.0\bn-BD\*.*" target="lib\net10.0\bn-BD" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -151,7 +151,7 @@ index 8a5fb02f..4656e6ba 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\cs\*.*" target="lib\netstandard1.0\cs" />
      <file src="Humanizer\bin\Release\netstandard2.0\cs\*.*" target="lib\netstandard2.0\cs" />
 -    <file src="Humanizer\bin\Release\net6.0\cs\*.*" target="lib\net6.0\cs" />
-+    <file src="Humanizer\bin\Release\net9.0\cs\*.*" target="lib\net9.0\cs" />
++    <file src="Humanizer\bin\Release\net10.0\cs\*.*" target="lib\net10.0\cs" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -167,7 +167,7 @@ index 4eeaf71d..447058cb 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\da\*.*" target="lib\netstandard1.0\da" />
      <file src="Humanizer\bin\Release\netstandard2.0\da\*.*" target="lib\netstandard2.0\da" />
 -    <file src="Humanizer\bin\Release\net6.0\da\*.*" target="lib\net6.0\da" />
-+    <file src="Humanizer\bin\Release\net9.0\da\*.*" target="lib\net9.0\da" />
++    <file src="Humanizer\bin\Release\net10.0\da\*.*" target="lib\net10.0\da" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -183,7 +183,7 @@ index 3e248dff..7fbb42fc 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\de\*.*" target="lib\netstandard1.0\de" />
      <file src="Humanizer\bin\Release\netstandard2.0\de\*.*" target="lib\netstandard2.0\de" />
 -    <file src="Humanizer\bin\Release\net6.0\de\*.*" target="lib\net6.0\de" />
-+    <file src="Humanizer\bin\Release\net9.0\de\*.*" target="lib\net9.0\de" />
++    <file src="Humanizer\bin\Release\net10.0\de\*.*" target="lib\net10.0\de" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -199,7 +199,7 @@ index 7bb205df..87509bc5 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\el\*.*" target="lib\netstandard1.0\el" />
      <file src="Humanizer\bin\Release\netstandard2.0\el\*.*" target="lib\netstandard2.0\el" />
 -    <file src="Humanizer\bin\Release\net6.0\el\*.*" target="lib\net6.0\el" />
-+    <file src="Humanizer\bin\Release\net9.0\el\*.*" target="lib\net9.0\el" />
++    <file src="Humanizer\bin\Release\net10.0\el\*.*" target="lib\net10.0\el" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -215,7 +215,7 @@ index cd050bdb..4928460f 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\es\*.*" target="lib\netstandard1.0\es" />
      <file src="Humanizer\bin\Release\netstandard2.0\es\*.*" target="lib\netstandard2.0\es" />
 -    <file src="Humanizer\bin\Release\net6.0\es\*.*" target="lib\net6.0\es" />
-+    <file src="Humanizer\bin\Release\net9.0\es\*.*" target="lib\net9.0\es" />
++    <file src="Humanizer\bin\Release\net10.0\es\*.*" target="lib\net10.0\es" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -231,7 +231,7 @@ index 3a8cc941..7196bf10 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\fa\*.*" target="lib\netstandard1.0\fa" />
      <file src="Humanizer\bin\Release\netstandard2.0\fa\*.*" target="lib\netstandard2.0\fa" />
 -    <file src="Humanizer\bin\Release\net6.0\fa\*.*" target="lib\net6.0\fa" />
-+    <file src="Humanizer\bin\Release\net9.0\fa\*.*" target="lib\net9.0\fa" />
++    <file src="Humanizer\bin\Release\net10.0\fa\*.*" target="lib\net10.0\fa" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -247,7 +247,7 @@ index 35796ee3..b183c3d8 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\fi-FI\*.*" target="lib\netstandard1.0\fi-FI" />
      <file src="Humanizer\bin\Release\netstandard2.0\fi-FI\*.*" target="lib\netstandard2.0\fi-FI" />
 -    <file src="Humanizer\bin\Release\net6.0\fi-FI\*.*" target="lib\net6.0\fi-FI" />
-+    <file src="Humanizer\bin\Release\net9.0\fi-FI\*.*" target="lib\net9.0\fi-FI" />
++    <file src="Humanizer\bin\Release\net10.0\fi-FI\*.*" target="lib\net10.0\fi-FI" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -263,7 +263,7 @@ index 0cd678b4..d23bd01f 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\fil-PH\*.*" target="lib\netstandard1.0\fil-PH" />
      <file src="Humanizer\bin\Release\netstandard2.0\fil-PH\*.*" target="lib\netstandard2.0\fil-PH" />
 -    <file src="Humanizer\bin\Release\net6.0\fil-PH\*.*" target="lib\net6.0\fil-PH" />
-+    <file src="Humanizer\bin\Release\net9.0\fil-PH\*.*" target="lib\net9.0\fil-PH" />
++    <file src="Humanizer\bin\Release\net10.0\fil-PH\*.*" target="lib\net10.0\fil-PH" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -279,7 +279,7 @@ index 6d2851e3..4e891ba3 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\fr-BE\*.*" target="lib\netstandard1.0\fr-BE" />
      <file src="Humanizer\bin\Release\netstandard2.0\fr-BE\*.*" target="lib\netstandard2.0\fr-BE" />
 -    <file src="Humanizer\bin\Release\net6.0\fr-BE\*.*" target="lib\net6.0\fr-BE" />
-+    <file src="Humanizer\bin\Release\net9.0\fr-BE\*.*" target="lib\net9.0\fr-BE" />
++    <file src="Humanizer\bin\Release\net10.0\fr-BE\*.*" target="lib\net10.0\fr-BE" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -295,7 +295,7 @@ index 5d84bd3c..ade764d0 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\fr\*.*" target="lib\netstandard1.0\fr" />
      <file src="Humanizer\bin\Release\netstandard2.0\fr\*.*" target="lib\netstandard2.0\fr" />
 -    <file src="Humanizer\bin\Release\net6.0\fr\*.*" target="lib\net6.0\fr" />
-+    <file src="Humanizer\bin\Release\net9.0\fr\*.*" target="lib\net9.0\fr" />
++    <file src="Humanizer\bin\Release\net10.0\fr\*.*" target="lib\net10.0\fr" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -311,7 +311,7 @@ index 4bd3936f..b4792ad3 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\he\*.*" target="lib\netstandard1.0\he" />
      <file src="Humanizer\bin\Release\netstandard2.0\he\*.*" target="lib\netstandard2.0\he" />
 -    <file src="Humanizer\bin\Release\net6.0\he\*.*" target="lib\net6.0\he" />
-+    <file src="Humanizer\bin\Release\net9.0\he\*.*" target="lib\net9.0\he" />
++    <file src="Humanizer\bin\Release\net10.0\he\*.*" target="lib\net10.0\he" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -327,7 +327,7 @@ index 736a05a3..6dc57145 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\hr\*.*" target="lib\netstandard1.0\hr" />
      <file src="Humanizer\bin\Release\netstandard2.0\hr\*.*" target="lib\netstandard2.0\hr" />
 -    <file src="Humanizer\bin\Release\net6.0\hr\*.*" target="lib\net6.0\hr" />
-+    <file src="Humanizer\bin\Release\net9.0\hr\*.*" target="lib\net9.0\hr" />
++    <file src="Humanizer\bin\Release\net10.0\hr\*.*" target="lib\net10.0\hr" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -343,7 +343,7 @@ index 3842c724..68e6f484 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\hu\*.*" target="lib\netstandard1.0\hu" />
      <file src="Humanizer\bin\Release\netstandard2.0\hu\*.*" target="lib\netstandard2.0\hu" />
 -    <file src="Humanizer\bin\Release\net6.0\hu\*.*" target="lib\net6.0\hu" />
-+    <file src="Humanizer\bin\Release\net9.0\hu\*.*" target="lib\net9.0\hu" />
++    <file src="Humanizer\bin\Release\net10.0\hu\*.*" target="lib\net10.0\hu" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -359,7 +359,7 @@ index ac8827dc..9b7a7c66 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\hy\*.*" target="lib\netstandard1.0\hy" />
      <file src="Humanizer\bin\Release\netstandard2.0\hy\*.*" target="lib\netstandard2.0\hy" />
 -    <file src="Humanizer\bin\Release\net6.0\hy\*.*" target="lib\net6.0\hy" />
-+    <file src="Humanizer\bin\Release\net9.0\hy\*.*" target="lib\net9.0\hy" />
++    <file src="Humanizer\bin\Release\net10.0\hy\*.*" target="lib\net10.0\hy" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -374,7 +374,7 @@ index c38c48cf..fbfebff0 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\id\*.*" target="lib\netstandard1.0\id" />
      <file src="Humanizer\bin\Release\netstandard2.0\id\*.*" target="lib\netstandard2.0\id" />
 -    <file src="Humanizer\bin\Release\net6.0\id\*.*" target="lib\net6.0\id" />
-+    <file src="Humanizer\bin\Release\net9.0\id\*.*" target="lib\net9.0\id" />
++    <file src="Humanizer\bin\Release\net10.0\id\*.*" target="lib\net10.0\id" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -390,7 +390,7 @@ index 0cedfee5..e54b1a25 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\is\*.*" target="lib\netstandard1.0\is" />
      <file src="Humanizer\bin\Release\netstandard2.0\is\*.*" target="lib\netstandard2.0\is" />
 -    <file src="Humanizer\bin\Release\net6.0\is\*.*" target="lib\net6.0\is" />
-+    <file src="Humanizer\bin\Release\net9.0\is\*.*" target="lib\net9.0\is" />
++    <file src="Humanizer\bin\Release\net10.0\is\*.*" target="lib\net10.0\is" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -406,7 +406,7 @@ index a6a1cc4b..215f127f 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\it\*.*" target="lib\netstandard1.0\it" />
      <file src="Humanizer\bin\Release\netstandard2.0\it\*.*" target="lib\netstandard2.0\it" />
 -    <file src="Humanizer\bin\Release\net6.0\it\*.*" target="lib\net6.0\it" />
-+    <file src="Humanizer\bin\Release\net9.0\it\*.*" target="lib\net9.0\it" />
++    <file src="Humanizer\bin\Release\net10.0\it\*.*" target="lib\net10.0\it" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -422,7 +422,7 @@ index 6da99ed6..3c77d2c7 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ja\*.*" target="lib\netstandard1.0\ja" />
      <file src="Humanizer\bin\Release\netstandard2.0\ja\*.*" target="lib\netstandard2.0\ja" />
 -    <file src="Humanizer\bin\Release\net6.0\ja\*.*" target="lib\net6.0\ja" />
-+    <file src="Humanizer\bin\Release\net9.0\ja\*.*" target="lib\net9.0\ja" />
++    <file src="Humanizer\bin\Release\net10.0\ja\*.*" target="lib\net10.0\ja" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -450,7 +450,7 @@ index 5c99b9f4..af3e4cd8 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ku\*.*" target="lib\netstandard1.0\ku" />
      <file src="Humanizer\bin\Release\netstandard2.0\ku\*.*" target="lib\netstandard2.0\ku" />
 -    <file src="Humanizer\bin\Release\net6.0\ku\*.*" target="lib\net6.0\ku" />
-+    <file src="Humanizer\bin\Release\net9.0\ku\*.*" target="lib\net9.0\ku" />
++    <file src="Humanizer\bin\Release\net10.0\ku\*.*" target="lib\net10.0\ku" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -466,7 +466,7 @@ index f2a5d1fa..61deda01 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\lv\*.*" target="lib\netstandard1.0\lv" />
      <file src="Humanizer\bin\Release\netstandard2.0\lv\*.*" target="lib\netstandard2.0\lv" />
 -    <file src="Humanizer\bin\Release\net6.0\lv\*.*" target="lib\net6.0\lv" />
-+    <file src="Humanizer\bin\Release\net9.0\lv\*.*" target="lib\net9.0\lv" />
++    <file src="Humanizer\bin\Release\net10.0\lv\*.*" target="lib\net10.0\lv" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -506,7 +506,7 @@ index 038c6f03..0e3a9b36 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\nb-NO\*.*" target="lib\netstandard1.0\nb-NO" />
      <file src="Humanizer\bin\Release\netstandard2.0\nb-NO\*.*" target="lib\netstandard2.0\nb-NO" />
 -    <file src="Humanizer\bin\Release\net6.0\nb-NO\*.*" target="lib\net6.0\nb-NO" />
-+    <file src="Humanizer\bin\Release\net9.0\nb-NO\*.*" target="lib\net9.0\nb-NO" />
++    <file src="Humanizer\bin\Release\net10.0\nb-NO\*.*" target="lib\net10.0\nb-NO" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -522,7 +522,7 @@ index f0cb4ac9..122e3ddd 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\nb\*.*" target="lib\netstandard1.0\nb" />
      <file src="Humanizer\bin\Release\netstandard2.0\nb\*.*" target="lib\netstandard2.0\nb" />
 -    <file src="Humanizer\bin\Release\net6.0\nb\*.*" target="lib\net6.0\nb" />
-+    <file src="Humanizer\bin\Release\net9.0\nb\*.*" target="lib\net9.0\nb" />
++    <file src="Humanizer\bin\Release\net10.0\nb\*.*" target="lib\net10.0\nb" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -538,7 +538,7 @@ index 8c495bc8..798b42c4 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\nl\*.*" target="lib\netstandard1.0\nl" />
      <file src="Humanizer\bin\Release\netstandard2.0\nl\*.*" target="lib\netstandard2.0\nl" />
 -    <file src="Humanizer\bin\Release\net6.0\nl\*.*" target="lib\net6.0\nl" />
-+    <file src="Humanizer\bin\Release\net9.0\nl\*.*" target="lib\net9.0\nl" />
++    <file src="Humanizer\bin\Release\net10.0\nl\*.*" target="lib\net10.0\nl" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -556,7 +556,7 @@ index c6e3a0f1..daf62b97 100644
 -      </group>
        <group targetFramework="netstandard2.0" />
 -      <group targetFramework="net6.0" />
-+      <group targetFramework="net9.0" />
++      <group targetFramework="net10.0" />
      </dependencies>
    </metadata>
    <files>
@@ -566,8 +566,8 @@ index c6e3a0f1..daf62b97 100644
      <file src="Humanizer\bin\Release\netstandard2.0\*.xml" target="lib\netstandard2.0" />
 -    <file src="Humanizer\bin\Release\net6.0\*.dll" target="lib\net6.0" />
 -    <file src="Humanizer\bin\Release\net6.0\*.xml" target="lib\net6.0" />
-+    <file src="Humanizer\bin\Release\net9.0\*.dll" target="lib\net9.0" />
-+    <file src="Humanizer\bin\Release\net9.0\*.xml" target="lib\net9.0" />
++    <file src="Humanizer\bin\Release\net10.0\*.dll" target="lib\net10.0" />
++    <file src="Humanizer\bin\Release\net10.0\*.xml" target="lib\net10.0" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -583,7 +583,7 @@ index 75593a0d..34c1c365 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\pl\*.*" target="lib\netstandard1.0\pl" />
      <file src="Humanizer\bin\Release\netstandard2.0\pl\*.*" target="lib\netstandard2.0\pl" />
 -    <file src="Humanizer\bin\Release\net6.0\pl\*.*" target="lib\net6.0\pl" />
-+    <file src="Humanizer\bin\Release\net9.0\pl\*.*" target="lib\net9.0\pl" />
++    <file src="Humanizer\bin\Release\net10.0\pl\*.*" target="lib\net10.0\pl" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -599,7 +599,7 @@ index 084ff713..b99d79bf 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\pt\*.*" target="lib\netstandard1.0\pt" />
      <file src="Humanizer\bin\Release\netstandard2.0\pt\*.*" target="lib\netstandard2.0\pt" />
 -    <file src="Humanizer\bin\Release\net6.0\pt\*.*" target="lib\net6.0\pt" />
-+    <file src="Humanizer\bin\Release\net9.0\pt\*.*" target="lib\net9.0\pt" />
++    <file src="Humanizer\bin\Release\net10.0\pt\*.*" target="lib\net10.0\pt" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -615,7 +615,7 @@ index 4eb8746c..11e9b471 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ro\*.*" target="lib\netstandard1.0\ro" />
      <file src="Humanizer\bin\Release\netstandard2.0\ro\*.*" target="lib\netstandard2.0\ro" />
 -    <file src="Humanizer\bin\Release\net6.0\ro\*.*" target="lib\net6.0\ro" />
-+    <file src="Humanizer\bin\Release\net9.0\ro\*.*" target="lib\net9.0\ro" />
++    <file src="Humanizer\bin\Release\net10.0\ro\*.*" target="lib\net10.0\ro" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -631,7 +631,7 @@ index 9c953e77..0c337ec8 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ru\*.*" target="lib\netstandard1.0\ru" />
      <file src="Humanizer\bin\Release\netstandard2.0\ru\*.*" target="lib\netstandard2.0\ru" />
 -    <file src="Humanizer\bin\Release\net6.0\ru\*.*" target="lib\net6.0\ru" />
-+    <file src="Humanizer\bin\Release\net9.0\ru\*.*" target="lib\net9.0\ru" />
++    <file src="Humanizer\bin\Release\net10.0\ru\*.*" target="lib\net10.0\ru" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -647,7 +647,7 @@ index 10ea8c0c..06f77fce 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\sk\*.*" target="lib\netstandard1.0\sk" />
      <file src="Humanizer\bin\Release\netstandard2.0\sk\*.*" target="lib\netstandard2.0\sk" />
 -    <file src="Humanizer\bin\Release\net6.0\sk\*.*" target="lib\net6.0\sk" />
-+    <file src="Humanizer\bin\Release\net9.0\sk\*.*" target="lib\net9.0\sk" />
++    <file src="Humanizer\bin\Release\net10.0\sk\*.*" target="lib\net10.0\sk" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -663,7 +663,7 @@ index 3ba1e174..91e77402 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\sl\*.*" target="lib\netstandard1.0\sl" />
      <file src="Humanizer\bin\Release\netstandard2.0\sl\*.*" target="lib\netstandard2.0\sl" />
 -    <file src="Humanizer\bin\Release\net6.0\sl\*.*" target="lib\net6.0\sl" />
-+    <file src="Humanizer\bin\Release\net9.0\sl\*.*" target="lib\net9.0\sl" />
++    <file src="Humanizer\bin\Release\net10.0\sl\*.*" target="lib\net10.0\sl" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -679,7 +679,7 @@ index 8312104d..884aa493 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\sr-Latn\*.*" target="lib\netstandard1.0\sr-Latn" />
      <file src="Humanizer\bin\Release\netstandard2.0\sr-Latn\*.*" target="lib\netstandard2.0\sr-Latn" />
 -    <file src="Humanizer\bin\Release\net6.0\sr-Latn\*.*" target="lib\net6.0\sr-Latn" />
-+    <file src="Humanizer\bin\Release\net9.0\sr-Latn\*.*" target="lib\net9.0\sr-Latn" />
++    <file src="Humanizer\bin\Release\net10.0\sr-Latn\*.*" target="lib\net10.0\sr-Latn" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -695,7 +695,7 @@ index 464a316c..6dfc894d 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\sr\*.*" target="lib\netstandard1.0\sr" />
      <file src="Humanizer\bin\Release\netstandard2.0\sr\*.*" target="lib\netstandard2.0\sr" />
 -    <file src="Humanizer\bin\Release\net6.0\sr\*.*" target="lib\net6.0\sr" />
-+    <file src="Humanizer\bin\Release\net9.0\sr\*.*" target="lib\net9.0\sr" />
++    <file src="Humanizer\bin\Release\net10.0\sr\*.*" target="lib\net10.0\sr" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -711,7 +711,7 @@ index 13215b74..1c63f8ac 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\sv\*.*" target="lib\netstandard1.0\sv" />
      <file src="Humanizer\bin\Release\netstandard2.0\sv\*.*" target="lib\netstandard2.0\sv" />
 -    <file src="Humanizer\bin\Release\net6.0\sv\*.*" target="lib\net6.0\sv" />
-+    <file src="Humanizer\bin\Release\net9.0\sv\*.*" target="lib\net9.0\sv" />
++    <file src="Humanizer\bin\Release\net10.0\sv\*.*" target="lib\net10.0\sv" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -727,7 +727,7 @@ index 74c9d434..f0065339 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\ta\*.*" target="lib\netstandard1.0\ta" />
      <file src="Humanizer\bin\Release\netstandard2.0\ta\*.*" target="lib\netstandard2.0\ta" />
 -    <file src="Humanizer\bin\Release\net6.0\ta\*.*" target="lib\net6.0\ta" />
-+    <file src="Humanizer\bin\Release\net9.0\ta\*.*" target="lib\net9.0\ta" />
++    <file src="Humanizer\bin\Release\net10.0\ta\*.*" target="lib\net10.0\ta" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -754,7 +754,7 @@ index c06ecea0..20b1dc40 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\tr\*.*" target="lib\netstandard1.0\tr" />
      <file src="Humanizer\bin\Release\netstandard2.0\tr\*.*" target="lib\netstandard2.0\tr" />
 -    <file src="Humanizer\bin\Release\net6.0\tr\*.*" target="lib\net6.0\tr" />
-+    <file src="Humanizer\bin\Release\net9.0\tr\*.*" target="lib\net9.0\tr" />
++    <file src="Humanizer\bin\Release\net10.0\tr\*.*" target="lib\net10.0\tr" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -770,7 +770,7 @@ index 489d09eb..3602cba8 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\uk\*.*" target="lib\netstandard1.0\uk" />
      <file src="Humanizer\bin\Release\netstandard2.0\uk\*.*" target="lib\netstandard2.0\uk" />
 -    <file src="Humanizer\bin\Release\net6.0\uk\*.*" target="lib\net6.0\uk" />
-+    <file src="Humanizer\bin\Release\net9.0\uk\*.*" target="lib\net9.0\uk" />
++    <file src="Humanizer\bin\Release\net10.0\uk\*.*" target="lib\net10.0\uk" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -786,7 +786,7 @@ index 324e201a..3d09d801 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\uz-Cyrl-UZ\*.*" target="lib\netstandard1.0\uz-Cyrl-UZ" />
      <file src="Humanizer\bin\Release\netstandard2.0\uz-Cyrl-UZ\*.*" target="lib\netstandard2.0\uz-Cyrl-UZ" />
 -    <file src="Humanizer\bin\Release\net6.0\uz-Cyrl-UZ\*.*" target="lib\net6.0\uz-Cyrl-UZ" />
-+    <file src="Humanizer\bin\Release\net9.0\uz-Cyrl-UZ\*.*" target="lib\net9.0\uz-Cyrl-UZ" />
++    <file src="Humanizer\bin\Release\net10.0\uz-Cyrl-UZ\*.*" target="lib\net10.0\uz-Cyrl-UZ" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -802,7 +802,7 @@ index 98668f0f..691d0c6d 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\uz-Latn-UZ\*.*" target="lib\netstandard1.0\uz-Latn-UZ" />
      <file src="Humanizer\bin\Release\netstandard2.0\uz-Latn-UZ\*.*" target="lib\netstandard2.0\uz-Latn-UZ" />
 -    <file src="Humanizer\bin\Release\net6.0\uz-Latn-UZ\*.*" target="lib\net6.0\uz-Latn-UZ" />
-+    <file src="Humanizer\bin\Release\net9.0\uz-Latn-UZ\*.*" target="lib\net9.0\uz-Latn-UZ" />
++    <file src="Humanizer\bin\Release\net10.0\uz-Latn-UZ\*.*" target="lib\net10.0\uz-Latn-UZ" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -818,7 +818,7 @@ index 1f7288b5..9d6218c5 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\vi\*.*" target="lib\netstandard1.0\vi" />
      <file src="Humanizer\bin\Release\netstandard2.0\vi\*.*" target="lib\netstandard2.0\vi" />
 -    <file src="Humanizer\bin\Release\net6.0\vi\*.*" target="lib\net6.0\vi" />
-+    <file src="Humanizer\bin\Release\net9.0\vi\*.*" target="lib\net9.0\vi" />
++    <file src="Humanizer\bin\Release\net10.0\vi\*.*" target="lib\net10.0\vi" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -834,7 +834,7 @@ index d693eb77..a29fe464 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\zh-CN\*.*" target="lib\netstandard1.0\zh-CN" />
      <file src="Humanizer\bin\Release\netstandard2.0\zh-CN\*.*" target="lib\netstandard2.0\zh-CN" />
 -    <file src="Humanizer\bin\Release\net6.0\zh-CN\*.*" target="lib\net6.0\zh-CN" />
-+    <file src="Humanizer\bin\Release\net9.0\zh-CN\*.*" target="lib\net9.0\zh-CN" />
++    <file src="Humanizer\bin\Release\net10.0\zh-CN\*.*" target="lib\net10.0\zh-CN" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -850,7 +850,7 @@ index daf32b8a..3d0dc105 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\zh-Hans\*.*" target="lib\netstandard1.0\zh-Hans" />
      <file src="Humanizer\bin\Release\netstandard2.0\zh-Hans\*.*" target="lib\netstandard2.0\zh-Hans" />
 -    <file src="Humanizer\bin\Release\net6.0\zh-Hans\*.*" target="lib\net6.0\zh-Hans" />
-+    <file src="Humanizer\bin\Release\net9.0\zh-Hans\*.*" target="lib\net9.0\zh-Hans" />
++    <file src="Humanizer\bin\Release\net10.0\zh-Hans\*.*" target="lib\net10.0\zh-Hans" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -866,7 +866,7 @@ index 0a219d40..457072e0 100644
 -    <file src="Humanizer\bin\Release\netstandard1.0\zh-Hant\*.*" target="lib\netstandard1.0\zh-Hant" />
      <file src="Humanizer\bin\Release\netstandard2.0\zh-Hant\*.*" target="lib\netstandard2.0\zh-Hant" />
 -    <file src="Humanizer\bin\Release\net6.0\zh-Hant\*.*" target="lib\net6.0\zh-Hant" />
-+    <file src="Humanizer\bin\Release\net9.0\zh-Hant\*.*" target="lib\net9.0\zh-Hant" />
++    <file src="Humanizer\bin\Release\net10.0\zh-Hant\*.*" target="lib\net10.0\zh-Hant" />
      <file src="..\logo.png" target="logo.png" />
    </files>
  </package>
@@ -895,7 +895,7 @@ index 5b2f8ad9..d8e36f6c 100644
  ﻿<Project Sdk="Microsoft.NET.Sdk">  
    <PropertyGroup>
 -    <TargetFrameworks>netstandard1.0;netstandard2.0;net6.0</TargetFrameworks>    
-+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>    
++    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>    
      <Authors>Mehdi Khalili, Claire Novotny</Authors>
      <PackageLicenseUrl>https://raw.githubusercontent.com/Humanizr/Humanizer/master/LICENSE</PackageLicenseUrl>
      <PackageProjectUrl>https://github.com/Humanizr/Humanizer</PackageProjectUrl>


### PR DESCRIPTION
Attempting to source build this repo with a new build of the .NET 10 SDK causes this error: 

```
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/Microsoft.Interop.ComInterfaceGenerator.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/Microsoft.Interop.JavaScript.JSImportGenerator.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/Microsoft.Interop.LibraryImportGenerator.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/Microsoft.Interop.SourceGeneration.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
CSC : error CS0006: Metadata file '/repos/dotnet/src/source-build-externals/artifacts/sb/package-cache/microsoft.netcore.app.ref/9.0.0/analyzers/dotnet/cs/System.Text.RegularExpressions.Generator.dll' could not be found [/repos/dotnet/src/source-build-externals/artifacts/sb/src/src/humanizer/src/Humanizer/Humanizer.csproj::TargetFramework=net9.0]
```

It's trying to load analyzers that come from the 9.0 targeting pack. Instead, it should be targeting net10.0 TFM.