### PR TITLE
Update vulnerable packages

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,5 +3,15 @@
 
 <UsageData>
   <IgnorePatterns>
+    <!-- Transitive dependencies from the msbuild intermediate -->
+    <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
+    <UsagePattern IdentityGlob="Microsoft.VisualStudio.SolutionPersistence/1.0.9" />
+    <UsagePattern IdentityGlob="System.CodeDom/8.0.0" />
+    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/8.0.0" />
+    <UsagePattern IdentityGlob="System.Diagnostics.EventLog/8.0.0" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/8.0.1" />
+    <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/8.0.0" />
+    <UsagePattern IdentityGlob="System.Resources.Extensions/8.0.0" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/8.0.0" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.Build" Version="17.14.0-preview-24619-01">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>e9b99f554a3c298e1106ea171f5a0462780af2c5</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.14.0-preview-24619-01">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>e9b99f554a3c298e1106ea171f5a0462780af2c5</Sha>
+      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.24613.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>255d5e0c89958af276883a988108c2d616438805</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,6 +18,6 @@
     <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.14.0-preview-24619-01</MicrosoftBuildVersion>
   </PropertyGroup>
 </Project>

--- a/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0001-fix-for-source-build.patch
+++ b/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0001-fix-for-source-build.patch
@@ -54,9 +54,11 @@ index 1e6f60cc..3287409f 100644
      <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
 -    <SystemSecurityCryptographyCngVersion>4.5.0</SystemSecurityCryptographyCngVersion>
 +    <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
-     <SystemTextJson>8.0.4</SystemTextJson>
+-    <SystemTextJson>8.0.4</SystemTextJson>
++    <SystemTextJson>8.0.5</SystemTextJson>
    </PropertyGroup>
  
+ </Project>
 diff --git a/build/targets.props b/build/targets.props
 index 6f92780d..1c48acfb 100644
 --- a/build/targets.props

--- a/repo-projects/docker-creds-provider.proj
+++ b/repo-projects/docker-creds-provider.proj
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DockerCredsProviderReleaseVersion>2.2.1</DockerCredsProviderReleaseVersion>
+    <DockerCredsProviderReleaseVersion>2.2.4</DockerCredsProviderReleaseVersion>
   </PropertyGroup>
 
   <Import Project="docker-creds-provider.targets" />

--- a/repo-projects/docker-creds-provider.targets
+++ b/repo-projects/docker-creds-provider.targets
@@ -6,6 +6,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)/global.json</GlobalJsonFile>
     <PackagesOutput>$(ProjectDirectory)/src/Valleysoft.DockerCredsProvider/bin/$(Configuration)/</PackagesOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #https://github.com/dotnet/source-build/issues/4752

- Update docker-cred-provider to update STJ from 6.0.0 to 8.0.5
- Update azure-activedirectory-identitymodel-extensions-for-dotnet patch to update STJ from 8.0.4 to 8.0.5
- Define darc dependency on MsBuild package to keep the package up-do-date.  This is what brought in the vulnerable System.Formats.Asn1.7.0.0 package.