### PR TITLE
[release/9.0] Update vulnerable packages

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,5 +3,13 @@
 
 <UsageData>
   <IgnorePatterns>
+    <!-- Transitive dependencies from the msbuild intermediate -->
+    <UsagePattern IdentityGlob="System.CodeDom/8.0.0" />
+    <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/8.0.0" />
+    <UsagePattern IdentityGlob="System.Diagnostics.EventLog/8.0.0" />
+    <UsagePattern IdentityGlob="System.Formats.Asn1/8.0.1" />
+    <UsagePattern IdentityGlob="System.Reflection.MetadataLoadContext/8.0.0" />
+    <UsagePattern IdentityGlob="System.Resources.Extensions/8.0.0" />
+    <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/8.0.0" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,9 +22,9 @@
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24405.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24619.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>0d066e61a30c2599d0ced871ea45acf0e10571af</Sha>
+      <Sha>e2b1d16fd66540b3a5813ec0ac1fd166688c3e0a</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.Build" Version="17.12.18">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>ed8c6aec5b774cfdad4e95033910c30aa0d93391</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.12.18-preview-24610-04">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>ed8c6aec5b774cfdad4e95033910c30aa0d93391</Sha>
+      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.24572.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>b41381d5cd633471265e9cd72e933a7048e03062</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,6 @@
     <XunitReleaseVersion>2.4.2</XunitReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.12.18</MicrosoftBuildVersion>
   </PropertyGroup>
 </Project>

--- a/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0001-fix-for-source-build.patch
+++ b/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/0001-fix-for-source-build.patch
@@ -54,9 +54,11 @@ index 1e6f60cc..3287409f 100644
      <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
 -    <SystemSecurityCryptographyCngVersion>4.5.0</SystemSecurityCryptographyCngVersion>
 +    <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
-     <SystemTextJson>8.0.4</SystemTextJson>
+-    <SystemTextJson>8.0.4</SystemTextJson>
++    <SystemTextJson>8.0.5</SystemTextJson>
    </PropertyGroup>
- 
+
+ </Project>
 diff --git a/build/targets.props b/build/targets.props
 index 6f92780d..1c48acfb 100644
 --- a/build/targets.props

--- a/repo-projects/docker-creds-provider.proj
+++ b/repo-projects/docker-creds-provider.proj
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DockerCredsProviderReleaseVersion>2.2.1</DockerCredsProviderReleaseVersion>
+    <DockerCredsProviderReleaseVersion>2.2.4</DockerCredsProviderReleaseVersion>
   </PropertyGroup>
 
   <Import Project="docker-creds-provider.targets" />

--- a/repo-projects/docker-creds-provider.targets
+++ b/repo-projects/docker-creds-provider.targets
@@ -6,6 +6,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <GlobalJsonFile>$(ProjectDirectory)/global.json</GlobalJsonFile>
     <PackagesOutput>$(ProjectDirectory)/src/Valleysoft.DockerCredsProvider/bin/$(Configuration)/</PackagesOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/source-build-externals/pull/423 to release/9.0