### PR TITLE
Enable NuGet Audit

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,4 +14,8 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>


### PR DESCRIPTION
Fixes #https://github.com/dotnet/source-build/issues/4672

I did not add https://github.com/dotnet/arcade/blob/5d30877b1eb318583acd5f2cd3f3a80e77b3add2/Directory.Build.props#L17-L18 because this would need to flow to the external repos in order to have an effect.  Repo patches would be needed for this.  I am of the opinion that we enable this and adjust if necessary.