### PR TITLE
Update vs-solutionpersistence to 1.0.52

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <CssParserReleaseVersionSuffix>20230414.1</CssParserReleaseVersionSuffix>
     <HumanizerReleaseVersion>2.14.1</HumanizerReleaseVersion>
     <MSBuildLocatorReleaseVersion>1.6.10</MSBuildLocatorReleaseVersion>
-    <SolutionPersistenceVersion>1.0.28</SolutionPersistenceVersion>
+    <SolutionPersistenceVersion>1.0.52</SolutionPersistenceVersion>
     <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
     <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Updates vs-solutionpersistence to new release [v.1.0.52](https://github.com/microsoft/vs-solutionpersistence/releases/tag/v1.0.52) with several bug fixes and improvements.

https://github.com/dotnet/sdk/issues/47297

## PR Checklist
If you are upgrading the version of a repo submodule, please follow this
checklist:

- [x] Provide a link to an issue in the consuming repo describing the need for
the upgrade. Both this PR and the PR doing the upgrade in the consuming repo
should link to that issue.
- [x] Have you done your due diligence to ensure the upgrade can be completed
in the consuming repo in a timely manner? If consuming the dependency flow of
this update takes a long time or needs to be backed out, it may require the
reversion of the upgrade in this PR. That's something we want to avoid.
- [x] When consuming the dependency flow from this repo for the purposes of a
version upgrade, consider using a separate PR or at least changing the title of
the dependency flow PR to accurately reflect the purpose of the change. Seeing
a PR named "Upgrade IdentityModel to 8.0.1", for example, provides better
clarity than "Update dependencies from dotnet/source-build-externals".
