### PR TITLE
Use assetless build for official build

### DIFF
--- a/.vsts.pipelines/builds/ci.yml
+++ b/.vsts.pipelines/builds/ci.yml
@@ -66,9 +66,5 @@ extends:
             - checkout: self
               submodules: recursive
             - template: /eng/common/templates-official/steps/source-build.yml
-    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
-      - template: /eng/common/templates-official/post-build/post-build.yml@self
-        parameters:
-          publishingInfraVersion: 3
-          enableSourceLinkValidation: true
-          enableSigningValidation: false
+          publishAssetsImmediately: true
+          isAssetlessBuild: true


### PR DESCRIPTION
Follow-up on d795fb17a0354099869692faaeafc3615c52a1d0 which removed the publish action from the source-build template. Make the official build an assetless build so that source changes flow into the VMR.

I mimicked https://github.com/dotnet/scenario-tests/commit/b77639a6d33c9a69cfcd3272ab4f8767d7ae02ea