### PR TITLE
Add back code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).


### PR DESCRIPTION
This adds back the code of conduct removed in https://github.com/dotnet/source-build-externals/pull/501.  The dotnet org policy requires this.