### PR TITLE
Specify sdk version in global.json

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-sdkLine=$(grep -m 1 'dotnet' "$scriptroot/global.json")
+sdkLine=$(grep -m 1 '"dotnet"' "$scriptroot/global.json")
 sdkPattern="\"dotnet\" *: *\"(.*)\""
 if [[ $sdkLine =~ $sdkPattern ]]; then
   export SDK_VERSION=${BASH_REMATCH[1]}

--- a/global.json
+++ b/global.json
@@ -1,4 +1,13 @@
 {
+  "sdk": {
+    "version": "9.0.112",
+    "rollForward": "latestPatch",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The required .NET SDK wasn't found."
+  },
   "tools": {
     "dotnet": "9.0.112"
   },

--- a/global.json
+++ b/global.json
@@ -5,8 +5,7 @@
     "paths": [
       ".dotnet",
       "$host$"
-    ],
-    "errorMessage": "The required .NET SDK wasn't found."
+    ]
   },
   "tools": {
     "dotnet": "9.0.112"


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5428

This PR specifies the sdk version (patch roll forward enabled) in the global.json, ensuring the build uses the correct SDK version.

Previously, builds could pick up a newer .NET SDK if it was installed, leading to version mismatches and MSBuild errors. Pinning the SDK version in global.json resolves this.

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2851316&view=results)