### PR TITLE
Specify sdk version in global.json

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-sdkLine=$(grep -m 1 'dotnet' "$scriptroot/global.json")
+sdkLine=$(grep -m 1 '"dotnet"' "$scriptroot/global.json")
 sdkPattern="\"dotnet\" *: *\"(.*)\""
 if [[ $sdkLine =~ $sdkPattern ]]; then
   export SDK_VERSION=${BASH_REMATCH[1]}

--- a/global.json
+++ b/global.json
@@ -1,4 +1,12 @@
 {
+  "sdk": {
+    "version": "8.0.122",
+    "rollForward": "latestPatch",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ]
+  },
   "tools": {
     "dotnet": "8.0.122"
   },


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/source-build-externals/pull/509.  Required after https://github.com/dotnet/source-build-externals/pull/514/changes/41ebbe3f6f01260e4f24d236e8f16094a25161a2 was merged.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2872514&view=results
