### PR TITLE
Address component governance alerts

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.Build" Version="17.8.5">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>b5265ef370a651f8c3458110b804e5cbf869eeb5</Sha>
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.8.5-preview-24055-02">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>b5265ef370a651f8c3458110b804e5cbf869eeb5</Sha>
-      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="System.Text.Json" Version="8.0.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d5fbb450c262fdab41bc94f8964865cd513c34d3</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,4 @@
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
   </PropertyGroup>
-  <PropertyGroup>
-    <MicrosoftBuildVersion>17.8.5</MicrosoftBuildVersion>
-  </PropertyGroup>
 </Project>

--- a/eng/tasks/Directory.Build.props
+++ b/eng/tasks/Directory.Build.props
@@ -16,6 +16,8 @@
     found when the task is loaded by the SDK's MSBuild.
   -->
   <ItemGroup>
+    <SdkAssembly Include="$(SdkReferenceDir)Microsoft.Build.Framework.dll" />
+    <SdkAssembly Include="$(SdkReferenceDir)Microsoft.Build.Utilities.Core.dll" />
     <SdkAssembly Include="$(SdkReferenceDir)Newtonsoft.Json.dll" />
 
     <SdkAssemblyReference

--- a/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
+++ b/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
@@ -13,13 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="@(SdkAssemblyReference)" />
   </ItemGroup>
 

--- a/patches/newtonsoft-json/0001-Newtonsoft.Json-project-updates.patch
+++ b/patches/newtonsoft-json/0001-Newtonsoft.Json-project-updates.patch
@@ -4,9 +4,22 @@ Date: Tue, 15 Aug 2023 09:49:47 -0500
 Subject: [PATCH] Newtonsoft.Json project updates
 
 ---
+ Src/global.json                           |  2 +-
  Src/Newtonsoft.Json/Newtonsoft.Json.csproj | 15 +++++----------
- 1 file changed, 5 insertions(+), 10 deletions(-)
+ 2 files changed, 6 insertions(+), 11 deletions(-)
 
+diff --git a/Src/global.json b/Src/global.json
+index 18b4598f..ea886fba 100644
+--- a/Src/global.json
++++ b/Src/global.json
+@@ -1,6 +1,6 @@
+ {
+   "sdk": {
+-    "version": "6.0.400",
++    "version": "8.0.126",
+     "rollForward": "latestFeature"
+   }
+ }
 diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
 index 47c63018..c939e71a 100644
 --- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj


### PR DESCRIPTION
Component Governance reports an unsupported .NET 6 SDK in the Newtonsoft.Json source tree and vulnerable MSBuild 17.8.5 packages used by the source-build task project.

This change updates the Newtonsoft.Json patch to use the supported .NET 8 SDK. It also stops restoring MSBuild packages for the task project and instead references the matching MSBuild assemblies supplied by the active SDK, removing both the vulnerable package registrations and the now-unused dependency-flow metadata.