### PR TITLE
Address release/9.0 component governance alerts

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.Build" Version="17.12.50">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>465c45808f0e9f3c32eb145101eeeccdc29d39e6</Sha>
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.12.50-preview-25517-02">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>465c45808f0e9f3c32eb145101eeeccdc29d39e6</Sha>
-      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.26372.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>16960d68c1325deaabd35f46313462b7c1070545</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,4 @@
     <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
     <XunitReleaseVersion>2.4.2</XunitReleaseVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <MicrosoftBuildVersion>17.12.50</MicrosoftBuildVersion>
-  </PropertyGroup>
 </Project>

--- a/eng/tasks/Directory.Build.props
+++ b/eng/tasks/Directory.Build.props
@@ -16,6 +16,8 @@
     found when the task is loaded by the SDK's MSBuild.
   -->
   <ItemGroup>
+    <SdkAssembly Include="$(SdkReferenceDir)Microsoft.Build.Framework.dll" />
+    <SdkAssembly Include="$(SdkReferenceDir)Microsoft.Build.Utilities.Core.dll" />
     <SdkAssembly Include="$(SdkReferenceDir)Newtonsoft.Json.dll" />
 
     <SdkAssemblyReference

--- a/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
+++ b/eng/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj
@@ -6,13 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="@(SdkAssemblyReference)" />
   </ItemGroup>
 

--- a/patches/newtonsoft-json/0001-Newtonsoft.Json-project-updates.patch
+++ b/patches/newtonsoft-json/0001-Newtonsoft.Json-project-updates.patch
@@ -4,9 +4,22 @@ Date: Tue, 15 Aug 2023 09:49:47 -0500
 Subject: [PATCH] Newtonsoft.Json project updates
 
 ---
+ Src/global.json                            |  2 +-
  Src/Newtonsoft.Json/Newtonsoft.Json.csproj | 15 +++++----------
- 1 file changed, 5 insertions(+), 10 deletions(-)
+ 2 files changed, 6 insertions(+), 11 deletions(-)
 
+diff --git a/Src/global.json b/Src/global.json
+index 18b4598f..ea886fba 100644
+--- a/Src/global.json
++++ b/Src/global.json
+@@ -1,6 +1,6 @@
+ {
+   "sdk": {
+-    "version": "6.0.400",
++    "version": "8.0.126",
+     "rollForward": "latestFeature"
+   }
+ }
 diff --git a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
 index 47c63018..c939e71a 100644
 --- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj


### PR DESCRIPTION
The release/9.0 Component Governance scan reports an unsupported .NET 6 SDK in the Newtonsoft.Json sources and vulnerable transitive dependencies from the MSBuild task packages.

This change:
- updates the Newtonsoft.Json source-build patch to select the supported .NET 8.0.126 SDK
- builds the source-build task against the active SDK's MSBuild assemblies instead of restoring separate Microsoft.Build packages
- removes the now-unused MSBuild dependency declarations

The Guardian alert is owned by Arcade-generated `eng/common` content and is intentionally excluded from this change; it must flow through an Arcade dependency update.